### PR TITLE
chore: add lint lockfile in ci and fix typo

### DIFF
--- a/.github/workflows/setup-lint-test.yml
+++ b/.github/workflows/setup-lint-test.yml
@@ -21,9 +21,13 @@ jobs:
           node-version: ${{ matrix.node-version }}
       # - name: Install Yarn
       #   run: npm install -g yarn  # required to run locally using act
-      - run: yarn setup
-      - run: yarn yarn-deduplicate 
-      - run: yarn lint
+      - name: Run Setup
+        run: yarn setup
+      - run: yarn yarn-deduplicate
+      - name: Run Lint 
+        run: yarn lint
+      - name: Run Lint lockfile
+        run: yarn lint:lockfile
       - name: Run Jest Tests
         run: yarn test:unit:jest --maxWorkers=2 --testTimeout=5000
       - name: Run Mocha Tests

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -33,7 +33,7 @@
   "portable": {
     "artifactName": "metamask-desktop-${version}-portable.${ext}"
   },
-  "productName": "Metamask Desktop",
+  "productName": "MetaMask Desktop",
   "win": {
     "icon": "app/build-types/desktop/images/icon-512.png",
     "target": ["nsis", "portable"]


### PR DESCRIPTION
## Overview
It includes the lint:lockfile on the CI to help keep our development as close as possible to MM-extension team. 

## Changes
### Desktop
No changes in the code itself, only include a new step in the ci pipeline.

### Extension
No changes.