### PR TITLE
Support external connection in the desktop app

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -507,7 +507,7 @@ function setupController(initState, initLangCode, remoteSourcePort) {
    */
   function connectRemote(remotePort) {
     if (desktopConnection) {
-      desktopConnection.createStream(remotePort);
+      desktopConnection.createStream(remotePort, false);
       return;
     }
 
@@ -613,7 +613,8 @@ function setupController(initState, initLangCode, remoteSourcePort) {
   // communication with page or other extension
   function connectExternal(remotePort) {
     if (desktopConnection) {
-      console.log('Ignored attempted external connection');
+      desktopConnection.createStream(remotePort, true);
+      console.debug('Create stream to external connection');
       return;
     }
 
@@ -777,7 +778,7 @@ function setupController(initState, initLangCode, remoteSourcePort) {
   }
 
   if (desktopApp) {
-    desktopApp.setConnectRemote(connectRemote);
+    desktopApp.setConnectRemote(connectRemote, connectExternal);
   }
 
   return Promise.resolve();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -614,7 +614,7 @@ function setupController(initState, initLangCode, remoteSourcePort) {
   function connectExternal(remotePort) {
     if (desktopConnection) {
       desktopConnection.createStream(remotePort, true);
-      console.debug('Create stream to external connection');
+      log.debug('Created stream for external connection');
       return;
     }
 
@@ -777,9 +777,13 @@ function setupController(initState, initLangCode, remoteSourcePort) {
     updateBadge();
   }
 
+  /**
+   * Once setConnectCallbacks is set, the desktop app can be called by the extension through the websocket.
+   * Consequently, we set those functions only once the MetaMask Controller is fully configured, e. g. at the whole end of the setupController function.
+   * This guarantees the desktop app can only be called by the extension when fully setup.
+   */
   if (desktopApp) {
-    desktopApp.setConnectRemote(connectRemote);
-    desktopApp.setConnectExternal(connectExternal);
+    desktopApp.setConnectCallbacks(connectRemote, connectExternal);
   }
 
   return Promise.resolve();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -778,7 +778,8 @@ function setupController(initState, initLangCode, remoteSourcePort) {
   }
 
   if (desktopApp) {
-    desktopApp.setConnectRemote(connectRemote, connectExternal);
+    desktopApp.setConnectRemote(connectRemote);
+    desktopApp.setConnectExternal(connectExternal);
   }
 
   return Promise.resolve();

--- a/app/scripts/desktop/desktop-connection.js
+++ b/app/scripts/desktop/desktop-connection.js
@@ -55,7 +55,13 @@ export default class DesktopConnection {
     log.debug('Sent extension state to desktop');
   }
 
-  createStream(remotePort) {
+  /**
+   * Creates a connection with the MetaMask Desktop via a multiplexed stream.
+   *
+   * @param {Port} remotePort - The port provided by a new context.
+   * @param {boolean} isExternal - Whether or not the new context is external (page or other extension).
+   */
+  createStream(remotePort, isExternal) {
     if (!this._webSocketStream) {
       this._connect();
     }
@@ -70,7 +76,7 @@ export default class DesktopConnection {
       this._onPortStreamEnd(clientId, clientStream),
     );
 
-    this._sendHandshake(remotePort, clientId);
+    this._sendHandshake(remotePort, clientId, isExternal);
   }
 
   async _onDisable(state) {
@@ -108,13 +114,14 @@ export default class DesktopConnection {
     this._connectionControllerStream.write({ clientId });
   }
 
-  _sendHandshake(remotePort, clientId) {
+  _sendHandshake(remotePort, clientId, isExternal) {
     const handshake = {
       clientId,
       remotePort: {
         name: remotePort.name,
         sender: remotePort.sender,
       },
+      isExternal,
     };
 
     log.debug('Sending handshake', handshake);

--- a/app/scripts/desktop/desktop.js
+++ b/app/scripts/desktop/desktop.js
@@ -125,6 +125,7 @@ export default class Desktop {
       clientId: data.clientId,
       name: data.remotePort.name,
       url: data.remotePort.sender.url,
+      isExternal: data.isExternal,
     });
 
     const { clientId } = data;
@@ -134,13 +135,23 @@ export default class Desktop {
 
     endOfStream(stream, () => this._onClientStreamEnd(clientId));
 
-    this._connectRemote({
-      ...data.remotePort,
-      stream,
-      onMessage: {
-        addListener: () => undefined,
-      },
-    });
+    if (data.isExternal) {
+      this._connectExternal({
+        ...data.remotePort,
+        stream,
+        onMessage: {
+          addListener: () => undefined,
+        },
+      });
+    } else {
+      this._connectRemote({
+        ...data.remotePort,
+        stream,
+        onMessage: {
+          addListener: () => undefined,
+        },
+      });
+    }
 
     this._connections.push(data);
     this._updateStatusWindow();

--- a/app/scripts/desktop/desktop.js
+++ b/app/scripts/desktop/desktop.js
@@ -67,11 +67,8 @@ export default class Desktop {
     this._disableStream.write(state);
   }
 
-  setConnectRemote(connectRemote) {
+  setConnectCallbacks(connectRemote, connectExternal) {
     this._connectRemote = connectRemote;
-  }
-
-  setConnectExternal(connectExternal) {
     this._connectExternal = connectExternal;
   }
 
@@ -132,29 +129,24 @@ export default class Desktop {
       isExternal: data.isExternal,
     });
 
-    const { clientId } = data;
+    const { clientId, isExternal } = data;
 
     const stream = this._multiplex.createStream(clientId);
+    const connectArgs = {
+      ...data.remotePort,
+      stream,
+      onMessage: {
+        addListener: () => undefined,
+      },
+    };
     this._clientStreams[clientId] = stream;
 
     endOfStream(stream, () => this._onClientStreamEnd(clientId));
 
-    if (data.isExternal) {
-      this._connectExternal({
-        ...data.remotePort,
-        stream,
-        onMessage: {
-          addListener: () => undefined,
-        },
-      });
+    if (isExternal) {
+      this._connectExternal(connectArgs);
     } else {
-      this._connectRemote({
-        ...data.remotePort,
-        stream,
-        onMessage: {
-          addListener: () => undefined,
-        },
-      });
+      this._connectRemote(connectArgs);
     }
 
     this._connections.push(data);

--- a/app/scripts/desktop/desktop.js
+++ b/app/scripts/desktop/desktop.js
@@ -71,6 +71,10 @@ export default class Desktop {
     this._connectRemote = connectRemote;
   }
 
+  setConnectExternal(connectExternal) {
+    this._connectExternal = connectExternal;
+  }
+
   showPopup() {
     this._browserControllerStream.write(BROWSER_ACTION_SHOW_POPUP);
   }

--- a/app/scripts/desktop/desktop.test.js
+++ b/app/scripts/desktop/desktop.test.js
@@ -232,8 +232,7 @@ describe('Desktop', () => {
   describe('on disconnect', () => {
     it('ends all multiplex client streams', async () => {
       await desktop.init();
-      desktop.setConnectRemote(connectRemoteMock);
-      desktop.setConnectExternal(connectExternalMock);
+      desktop.setConnectCallbacks(connectRemoteMock, connectExternalMock);
 
       await simulateNodeEvent(webSocketServerMock, 'connection', webSocketMock);
 
@@ -256,11 +255,10 @@ describe('Desktop', () => {
   describe('on handshake', () => {
     beforeEach(async () => {
       await desktop.init();
-      desktop.setConnectRemote(connectRemoteMock);
-      desktop.setConnectExternal(connectExternalMock);
+      desktop.setConnectCallbacks(connectRemoteMock, connectExternalMock);
     });
 
-    it('creates background connection using new multiplex stream', async () => {
+    it('creates background remote connection using new multiplex stream', async () => {
       const handshakeStreamMock = multiplexStreamMocks[CLIENT_ID_HANDSHAKES];
 
       await simulateStreamMessage(handshakeStreamMock, HANDSHAKE_MOCK);
@@ -282,7 +280,7 @@ describe('Desktop', () => {
       expect(connectExternalMock).toHaveBeenCalledTimes(0);
     });
 
-    it('creates background connection using new multiplex stream for external connection', async () => {
+    it('creates background external connection using new multiplex stream', async () => {
       const handshakeStreamMock = multiplexStreamMocks[CLIENT_ID_HANDSHAKES];
 
       await simulateStreamMessage(handshakeStreamMock, {
@@ -304,7 +302,6 @@ describe('Desktop', () => {
           addListener: expect.any(Function),
         },
       });
-
       expect(connectRemoteMock).toHaveBeenCalledTimes(0);
     });
   });
@@ -312,8 +309,7 @@ describe('Desktop', () => {
   describe('on connection controller message', () => {
     it('ends multiplex client stream', async () => {
       await desktop.init();
-      desktop.setConnectRemote(connectRemoteMock);
-      desktop.setConnectExternal(connectExternalMock);
+      desktop.setConnectCallbacks(connectRemoteMock, connectExternalMock);
 
       const handshakeStreamMock = multiplexStreamMocks[CLIENT_ID_HANDSHAKES];
       await simulateStreamMessage(handshakeStreamMock, HANDSHAKE_MOCK);

--- a/app/scripts/desktop/test/utils.js
+++ b/app/scripts/desktop/test/utils.js
@@ -21,6 +21,7 @@ export const RESULT_MOCK = 'testResult';
 export const HANDSHAKE_MOCK = {
   clientId: CLIENT_ID_MOCK,
   remotePort: { name: REMOTE_PORT_NAME_MOCK, sender: REMOTE_PORT_SENDER_MOCK },
+  isExternal: false,
 };
 
 export const flushPromises = () =>


### PR DESCRIPTION
# Overview

Support external connection between pages or another extension and MM-extension->desktop.

# Changes

## Desktop

- When a Stream is created now a new param is included to identify if the connection is external.
- On receiving a message containing specific data, referred to as a handshake, a connection is simulated in the background script by invoking `connectExternal`.

## Extension

- Whenever an extension/page tries to open an external connection, a PortStream is created using the provided remote port alongside an identifier `isExternal: true`, and all requests are piped to the desktop via a custom web socket Node stream.