### PR TITLE
Support phishing warning in desktop mode

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -205,6 +205,10 @@ async function initialize(remotePort) {
   await initDesktopConnection(initState);
   await setupController(initState, initLangCode, remotePort);
 
+  if (!cfg().desktop.isApp) {
+    await loadPhishingWarningPage();
+  }
+
   log.info('MetaMask initialization complete.');
 }
 
@@ -601,7 +605,10 @@ function setupController(initState, initLangCode, remoteSourcePort) {
       senderUrl.origin === phishingPageUrl.origin &&
       senderUrl.pathname === phishingPageUrl.pathname
     ) {
-      const portStream = new PortStream(remotePort);
+      const portStream = cfg().desktop.isApp
+        ? remotePort.stream
+        : new PortStream(remotePort);
+
       controller.setupPhishingCommunication({
         connectionStream: portStream,
       });

--- a/development/build-desktop.sh
+++ b/development/build-desktop.sh
@@ -23,7 +23,10 @@ set -a
 
 # Set desktop specific variables
 DESKTOP=APP
-echo "$DESKTOP"
+echo "Desktop Mode: $DESKTOP"
+
+PHISHING_WARNING_PAGE_URL=https://metamask.github.io/phishing-warning/v1.1.0/
+echo "Phishing Warning Page URL: $PHISHING_WARNING_PAGE_URL"
 
 # Add variables from .metamaskrc
 # shellcheck disable=SC2046


### PR DESCRIPTION
# Overview

Support phishing warning when in desktop mode.

# Changes

## Desktop

- Use desktop stream when creating phishing connection.
- Set correct phishing warning page URL during build to support user override.