### PR TITLE
Add apple sign config dev mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
   ignorePatterns: [
     'app/vendor/**',
     'builds/**/*',
+    'builds_desktop/**/*',
     'development/chromereload.js',
     'development/charts/**',
     'development/ts-migration-dashboard/build/**',

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ tsout/
 
 # Test results
 test-results/
+
+# Metamask Desktop packaging configuration
+.apprc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,9 @@
 node_modules/**
 lavamoat/**/policy.json
 dist/**
+dist_desktop/**
 builds/**
+builds_desktop/**
 test-*/**
 coverage/
 jest-coverage/

--- a/development/desktop/electron/build/entitlements.mac.plist
+++ b/development/desktop/electron/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.device.usb</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>

--- a/development/desktop/electron/scripts/notarize.js
+++ b/development/desktop/electron/scripts/notarize.js
@@ -1,0 +1,52 @@
+const path = require('path');
+const { readFile } = require('fs/promises');
+const ini = require('ini');
+const { notarize } = require('electron-notarize');
+
+const configurationPropertyNames = ['APPLEID', 'APPLEIDPASS'];
+
+async function getConfig() {
+  const configPath = path.resolve(__dirname, '.apprc');
+  let configContents = '';
+  try {
+    configContents = await readFile(configPath, {
+      encoding: 'utf8',
+    });
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const environmentVariables = {};
+  for (const propertyName of configurationPropertyNames) {
+    if (process.env[propertyName]) {
+      environmentVariables[propertyName] = process.env[propertyName];
+    }
+  }
+
+  return {
+    APPLE_ID: process.env.APPLE_ID,
+    APPLE_ID_PASS: process.env.APPLE_ID_PASS,
+    APP_BUNDLE_ID: process.env.APP_BUNDLE_ID,
+    ...ini.parse(configContents),
+  };
+}
+
+module.exports = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context;
+  if (electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  const appName = context.packager.appInfo.productFilename;
+
+  const config = await getConfig();
+
+  await notarize({
+    appBundleId: config.APP_BUNDLE_ID,
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: config.APPLE_ID,
+    appleIdPassword: config.APPLE_ID_PASS,
+  });
+};

--- a/electron-builder.ci.json
+++ b/electron-builder.ci.json
@@ -1,8 +1,12 @@
 {
+  "afterSign": "development/desktop/electron/scripts/notarize.js",
   "appId": "consensys.metamask.desktop",
   "asar": false,
   "directories": {
     "output": "builds_desktop"
+  },
+  "dmg": {
+    "sign": false
   },
   "files": ["dist_desktop/**/*", "node_modules/**/*", "package.json"],
   "linux": {
@@ -14,10 +18,6 @@
       "provider": "github"
     }
   },
-  "dmg": {
-    "sign": false
-  },
-  "afterSign": "development/desktop/electron/scripts/notarize.js",
   "mac": {
     "icon": "app/build-types/desktop/images/icon.icns",
     "forceCodeSigning": true,

--- a/electron-builder.ci.json
+++ b/electron-builder.ci.json
@@ -1,0 +1,51 @@
+{
+  "appId": "consensys.metamask.desktop",
+  "asar": false,
+  "directories": {
+    "output": "builds_desktop"
+  },
+  "files": ["dist_desktop/**/*", "node_modules/**/*", "package.json"],
+  "linux": {
+    "icon": "app/build-types/desktop/images/icon-512.png",
+    "target": "AppImage",
+    "category": "Utility",
+    "artifactName": "metamask-desktop-${version}.${ext}",
+    "publish": {
+      "provider": "github"
+    }
+  },
+  "dmg": {
+    "sign": false
+  },
+  "afterSign": "development/desktop/electron/scripts/notarize.js",
+  "mac": {
+    "icon": "app/build-types/desktop/images/icon.icns",
+    "forceCodeSigning": true,
+    "hardenedRuntime": true,
+    "entitlements": "development/desktop/electron/build/entitlements.mac.plist",
+    "entitlementsInherit": "development/desktop/electron/build/entitlements.mac.plist",
+    "gatekeeperAssess": false,
+    "type": "distribution",
+    "target": [
+      {
+        "target": "dmg",
+        "arch": ["x64", "arm64"]
+      }
+    ]
+  },
+  "npmRebuild": false,
+  "nsis": {
+    "oneClick": false,
+    "allowToChangeInstallationDirectory": true,
+    "deleteAppDataOnUninstall": true,
+    "artifactName": "metamask-desktop-${version}-setup.${ext}"
+  },
+  "portable": {
+    "artifactName": "metamask-desktop-${version}-portable.${ext}"
+  },
+  "productName": "MetaMask Desktop",
+  "win": {
+    "icon": "app/build-types/desktop/images/icon-512.png",
+    "target": ["nsis", "portable"]
+  }
+}

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -16,6 +16,12 @@
   },
   "mac": {
     "icon": "app/build-types/desktop/images/icon.icns",
+    "forceCodeSigning": true,
+    "hardenedRuntime": true,
+    "entitlements": "development/desktop/electron/build/entitlements.mac.plist",
+    "entitlementsInherit": "development/desktop/electron/build/entitlements.mac.plist",
+    "gatekeeperAssess": false,
+    "type": "development",
     "target": [
       {
         "target": "dmg",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "ts-migration:dashboard:deploy": "gh-pages --dist development/ts-migration-dashboard/build --remote ts-migration-dashboard",
     "electron:build:linux": "electron-builder -l",
     "electron:build:mac": "electron-builder -m",
+    "electron:build:mac:ci": "electron-builder --config electron-builder.ci.json -m",
     "electron:build:win": "electron-builder -w",
     "electron:release:linux": "electron-builder -l -p 'onTagOrDraft'"
   },
@@ -335,6 +336,7 @@
     "duplexify": "^4.1.1",
     "electron": "22.0.0-alpha.1",
     "electron-builder": "^23.3.3",
+    "electron-notarize": "^1.2.1",
     "electron-rebuild": "^3.2.9",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11674,6 +11674,14 @@ electron-builder@^23.3.3:
     update-notifier "^5.1.0"
     yargs "^17.0.1"
 
+electron-notarize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/electron-notarize/-/electron-notarize-1.2.1.tgz#347c18eca8e29dddadadee511b870c13d4008baf"
+  integrity sha512-u/ECWhIrhkSQpZM4cJzVZ5TsmkaqrRo5LDC/KMbGF0sPkm53Ng59+M0zp8QVaql0obfJy9vlVT+4iOkAi2UDlA==
+  dependencies:
+    debug "^4.1.1"
+    fs-extra "^9.0.1"
+
 electron-osx-sign@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.6.0.tgz#9b69c191d471d9458ef5b1e4fdd52baa059f1bb8"


### PR DESCRIPTION
# Overview
Add the required configuration for local signing the desktop app with target MacOS.
Also added the required configuration for notarizing the app (this should only be executed in the CI with the correct `Developer ID Application` certificates.

# Changes
## Desktop
No changes

## Extension
No Changes

## Other
* updated the existing `electron-builder.json` file to include all the required changes for local app signing.
* added plist file (with required entitlements). This was required due to enabling the `HardenedRuntime` option.
* added an `electron-builder.ci.json`. This config file is the one that should be used in the CI. Besides signing, it includes the notarization process.
* added a notarized.js script

## How to sign and package the app (MacOS only)
1. Get an apple development certificate (you can generate those using xcode)
2. Ensure that xcode has automatically downloaded you the `Apple Worldwide Developer Relations Certification Authority` and `Developer ID Certification Authority`. Those are important. Without those, your newly generated certificates won't be trusted
3. ensure that you have the app all set up (`yarn setup` + `yarn build:desktop`)
4. run the script to package the app `yarn electron:build:mac`
5. Test installing the generated package. According to Apple you should - https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW26
