### PR TITLE
fix skip OTP pairing using flag

### DIFF
--- a/app/scripts/desktop/README.md
+++ b/app/scripts/desktop/README.md
@@ -32,3 +32,11 @@ Run unit tests and the linter with `yarn test`. To run just unit tests, run `yar
 
 You can run the linter by itself with `yarn lint`, and you can automatically fix some lint problems with `yarn lint:fix`. You can also run these two commands just on your local changes to save time with `yarn lint:changed` and `yarn lint:changed:fix` respectively.
 
+
+### Environment Variables
+
+#### Development
+
+| Name | Description |
+| ---  | --- |
+| SKIP_OTP_PAIRING_FLOW | Whether set to `1` skips the OTP pairing flow. |

--- a/ui/pages/settings/experimental-tab/experimental-tab.component.js
+++ b/ui/pages/settings/experimental-tab/experimental-tab.component.js
@@ -239,7 +239,7 @@ export default class ExperimentalTab extends PureComponent {
 
   renderDesktopToggle() {
     const { t } = this.context;
-    const { desktopEnabled, setDesktopEnabled } = this.props;
+    const { desktopEnabled, setDesktopEnabled, setIsPairing } = this.props;
 
     return (
       <div ref={this.settingsRefs[5]} className="settings-page__content-row">
@@ -262,6 +262,7 @@ export default class ExperimentalTab extends PureComponent {
                     legacy_event: true,
                   },
                 });
+                setIsPairing(!value);
                 setDesktopEnabled(!value);
               }}
               offLabel={t('off')}


### PR DESCRIPTION
# Overview
Currently, the flag `SKIP_OTP_PAIRING_FLOW` is not bypassing the OTP pairing flow properly.

# Changes
## Desktop
Added in the toggle `renderDesktopToggle` the function `setIsPairing()` alongside the existing `desktopEnabled()` to properly bypass the OTP pairing flow and leaving with the toggle the responsibility to enable the "desktop mode".

## Other
Nothing else