### PR TITLE
Use compatibility versions in version check

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -15,3 +15,18 @@ SIWE_V1=
 
 ; Set this to test changes to the phishing warning page.
 PHISHING_WARNING_PAGE_URL=
+
+; Set this to '1' to generate additional log messages.
+METAMASK_DEBUG=
+
+; Desktop
+
+; Override the compatibility versions used to verify if the current desktop app and extension support each other.
+COMPATIBILITY_VERSION_DESKTOP=
+COMPATIBILITY_VERSION_EXTENSION=
+
+; Set this to '1' to disable all encryption when communicating with the desktop app.
+DISABLE_WEB_SOCKET_ENCRYPTION=
+
+; Set this to '1' to skip the pairing process when enabling desktop mode.
+SKIP_OTP_PAIRING_FLOW=

--- a/app/scripts/desktop/README.md
+++ b/app/scripts/desktop/README.md
@@ -39,4 +39,7 @@ You can run the linter by itself with `yarn lint`, and you can automatically fix
 
 | Name | Description |
 | ---  | --- |
-| SKIP_OTP_PAIRING_FLOW | Whether set to `1` skips the OTP pairing flow. |
+| COMPATIBILITY_VERSION_DESKTOP | Override the compatibility version of the desktop app. |
+| COMPATIBILITY_VERSION_EXTENSION | Override the compatibility version of the extension app. |
+| DISABLE_WEB_SOCKET_ENCRYPTION | Set this to `1` to disable all encryption when communicating with the desktop app. |
+| SKIP_OTP_PAIRING_FLOW | Set this to `1` to skip the pairing process when enabling desktop mode. |

--- a/app/scripts/desktop/shared/version-check.ts
+++ b/app/scripts/desktop/shared/version-check.ts
@@ -7,18 +7,9 @@ import {
 } from '../types/message';
 import { waitForMessage } from '../utils/stream';
 import { getVersion } from '../utils/version';
-
-const checkIfOverridden = (hardcodedValue: number, envValue?: string) => {
-  if (envValue) {
-    return parseInt(envValue, 10);
-  }
-
-  return hardcodedValue;
-};
+import cfg from '../utils/config';
 
 ///: BEGIN:ONLY_INCLUDE_IN(desktopapp)
-
-const COMPATIBILITY_VERSION_DESKTOP = 1;
 
 export class DesktopVersionCheck {
   private stream: Duplex;
@@ -38,14 +29,9 @@ export class DesktopVersionCheck {
 
     const { extensionVersionData } = data;
 
-    const desktopCompatibilityVersion = checkIfOverridden(
-      COMPATIBILITY_VERSION_DESKTOP,
-      process.env.COMPATIBILITY_VERSION_DESKTOP,
-    );
-
     const desktopVersionData = {
       version: getVersion(),
-      compatibilityVersion: desktopCompatibilityVersion,
+      compatibilityVersion: cfg().desktop.compatibilityVersion.desktop,
     };
 
     const isExtensionSupported = this.isExtensionVersionSupported(
@@ -77,8 +63,6 @@ export class DesktopVersionCheck {
 
 ///: BEGIN:ONLY_INCLUDE_IN(desktopextension)
 
-const COMPATIBILITY_VERSION_EXTENSION = 1;
-
 export class ExtensionVersionCheck {
   private stream: Duplex;
 
@@ -89,14 +73,9 @@ export class ExtensionVersionCheck {
   public async check(): Promise<VersionCheckResult> {
     log.debug('Checking versions');
 
-    const extensionCompatibilityVersion = checkIfOverridden(
-      COMPATIBILITY_VERSION_EXTENSION,
-      process.env.COMPATIBILITY_VERSION_EXTENSION,
-    );
-
     const extensionVersionData = {
       version: getVersion(),
-      compatibilityVersion: extensionCompatibilityVersion,
+      compatibilityVersion: cfg().desktop.compatibilityVersion.extension,
     };
 
     const checkVersionRequest: CheckVersionRequestMessage = {

--- a/app/scripts/desktop/types/desktop.ts
+++ b/app/scripts/desktop/types/desktop.ts
@@ -16,3 +16,8 @@ export interface TestConnectionResult {
   isConnected: boolean;
   versionCheck?: VersionCheckResult;
 }
+
+export interface VersionData {
+  version: string;
+  compatibilityVersion: number;
+}

--- a/app/scripts/desktop/types/message.ts
+++ b/app/scripts/desktop/types/message.ts
@@ -1,5 +1,5 @@
 import { ConnectionType, RemotePortData } from './background';
-import { ClientId } from './desktop';
+import { ClientId, VersionData } from './desktop';
 
 export interface NewConnectionMessage {
   clientId: ClientId;
@@ -39,7 +39,11 @@ export type PairingKeyResponseMessage = {
   pairingKey: string | undefined;
 };
 
-export type VersionMessage = {
-  version: string;
-  isValid?: boolean;
+export type CheckVersionRequestMessage = {
+  extensionVersionData: VersionData;
+};
+
+export type CheckVersionResponseMessage = {
+  desktopVersionData: VersionData;
+  isExtensionSupported: boolean;
 };

--- a/app/scripts/desktop/utils/config.ts
+++ b/app/scripts/desktop/utils/config.ts
@@ -21,15 +21,19 @@ const loadConfig = () => {
 
   return {
     desktop: {
+      enableUpdates: envStringMatch(process.env.DESKTOP_ENABLE_UPDATES, 'true'),
       isTest: envStringMatch(process.env.APP_ENV, 'TEST'),
       mv3: Boolean(process.env.ENABLE_MV3),
+      skipOtpPairingFlow: Boolean(process.env.SKIP_OTP_PAIRING_FLOW),
+      compatibilityVersion: {
+        desktop: envInt(process.env.COMPATIBILITY_VERSION_DESKTOP, 1),
+        extension: envInt(process.env.COMPATIBILITY_VERSION_EXTENSION, 1),
+      },
       webSocket: {
+        disableEncryption: Boolean(process.env.DISABLE_WEB_SOCKET_ENCRYPTION),
         port,
         url: `ws://localhost:${port}`,
-        disableEncryption: Boolean(process.env.DISABLE_WEB_SOCKET_ENCRYPTION),
       },
-      enableUpdates: envStringMatch(process.env.DESKTOP_ENABLE_UPDATES, 'true'),
-      skipOtpPairingFlow: Boolean(process.env.SKIP_OTP_PAIRING_FLOW),
     },
   };
 };

--- a/development/build/config.js
+++ b/development/build/config.js
@@ -17,7 +17,11 @@ const configurationPropertyNames = [
   'SENTRY_DSN_DEV',
   'SIWE_V1',
   'SWAPS_USE_DEV_APIS',
+  // Desktop
+  'COMPATIBILITY_VERSION_EXTENSION',
   'DISABLE_WEB_SOCKET_ENCRYPTION',
+  'METAMASK_DEBUG',
+  'SKIP_OTP_PAIRING_FLOW',
 ];
 
 const productionConfigurationPropertyNames = [
@@ -57,22 +61,6 @@ async function getConfig() {
   }
 
   return {
-    COLLECTIBLES_V1: process.env.COLLECTIBLES_V1,
-    INFURA_PROJECT_ID: process.env.INFURA_PROJECT_ID,
-    ONBOARDING_V2: process.env.ONBOARDING_V2,
-    PHISHING_WARNING_PAGE_URL: process.env.PHISHING_WARNING_PAGE_URL,
-    PUBNUB_PUB_KEY: process.env.PUBNUB_PUB_KEY,
-    PUBNUB_SUB_KEY: process.env.PUBNUB_SUB_KEY,
-    SEGMENT_HOST: process.env.SEGMENT_HOST,
-    SEGMENT_WRITE_KEY: process.env.SEGMENT_WRITE_KEY,
-    SENTRY_DSN_DEV:
-      process.env.SENTRY_DSN_DEV ??
-      'https://f59f3dd640d2429d9d0e2445a87ea8e1@sentry.io/273496',
-    SIWE_V1: process.env.SIWE_V1,
-    SWAPS_USE_DEV_APIS: process.env.SWAPS_USE_DEV_APIS,
-    METAMASK_DEBUG: process.env.METAMASK_DEBUG,
-    DISABLE_WEB_SOCKET_ENCRYPTION: process.env.DISABLE_WEB_SOCKET_ENCRYPTION,
-    SKIP_OTP_PAIRING_FLOW: process.env.SKIP_OTP_PAIRING_FLOW,
     ...ini.parse(configContents),
     ...environmentVariables,
   };

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -1051,9 +1051,7 @@ async function getEnvironmentVariables({ buildTarget, buildType, version }) {
   return {
     COLLECTIBLES_V1: config.COLLECTIBLES_V1 === '1',
     CONF: devMode ? config : {},
-    DISABLE_WEB_SOCKET_ENCRYPTION: config.DISABLE_WEB_SOCKET_ENCRYPTION === '1',
     ICON_NAMES: iconNames,
-    SKIP_OTP_PAIRING_FLOW: config.SKIP_OTP_PAIRING_FLOW === '1',
     IN_TEST: testing,
     INFURA_PROJECT_ID: getInfuraProjectId({
       buildType,
@@ -1078,6 +1076,10 @@ async function getEnvironmentVariables({ buildTarget, buildType, version }) {
     SIWE_V1: config.SIWE_V1 === '1',
     SWAPS_USE_DEV_APIS: config.SWAPS_USE_DEV_APIS === '1',
     TOKEN_ALLOWANCE_IMPROVEMENTS: config.TOKEN_ALLOWANCE_IMPROVEMENTS === '1',
+    // Desktop
+    COMPATIBILITY_VERSION_EXTENSION: config.COMPATIBILITY_VERSION_EXTENSION,
+    DISABLE_WEB_SOCKET_ENCRYPTION: config.DISABLE_WEB_SOCKET_ENCRYPTION === '1',
+    SKIP_OTP_PAIRING_FLOW: config.SKIP_OTP_PAIRING_FLOW === '1',
   };
 }
 

--- a/ui/desktop/locales/en.js
+++ b/ui/desktop/locales/en.js
@@ -42,7 +42,7 @@ const enLocales = {
     message: 'Sync with Extension',
   },
   typeTheSixDigitCodeBelow: {
-    message: 'Open your MetaMask Extansion and type the six-digit code below.',
+    message: 'Open your MetaMask Extension and type the six-digit code below.',
   },
   theme: {
     message: 'Theme',

--- a/ui/pages/desktop-error/render-desktop-error.js
+++ b/ui/pages/desktop-error/render-desktop-error.js
@@ -106,7 +106,7 @@ export function renderDesktopError({
           {renderCTA(
             'desktop-error-button-update-mmd',
             t('desktopOutdatedErrorCTA'),
-            noop,
+            downloadDesktopApp,
           )}
         </>
       );


### PR DESCRIPTION
# Overview

Use hardcoded compatibility versions to verify if the desktop app and extension support each other.

# Changes

## Desktop

- Define initial compatibility version set to `1`.
- Support testing via `COMPATIBILITY_VERSION_DESKTOP` variable in envs or `.metamaskrc`.

## Extension

- Define initial compatibility version set to `1`.
- Support testing via `COMPATIBILITY_VERSION_EXTENSION` variable in envs or `.metamaskrc`.
- Implement upgrade CTA on outdated desktop error.

## Other

- Define more specific types for request and response messages used in version check.
- Update environment variables in desktop README and `.metamaskrc.dist`.