### PR TITLE
Protect pairing key in extension

### DIFF
--- a/app/scripts/controllers/desktop.ts
+++ b/app/scripts/controllers/desktop.ts
@@ -18,6 +18,7 @@ export default class DesktopController {
     this.store = new ObservableStore({
       desktopEnabled: false,
       pairingKey: undefined,
+      pairingKeyHash: undefined,
       ...initState,
     });
   }

--- a/app/scripts/desktop/extension/desktop-connection.test.ts
+++ b/app/scripts/desktop/extension/desktop-connection.test.ts
@@ -18,6 +18,7 @@ import {
   UUID_MOCK,
   createExtensionVersionCheckMock,
   createExtensionPairingMock,
+  DATA_2_MOCK,
 } from '../test/mocks';
 import {
   simulateStreamMessage,
@@ -116,6 +117,10 @@ describe('Desktop Connection', () => {
     uuidMock.mockReturnValue(UUID_MOCK);
     extensionPairingMock.init.mockReturnValue(extensionPairingMock);
 
+    rawStateMock.addPairingKey.mockImplementation((data) =>
+      Promise.resolve(data),
+    );
+
     multiplexMock.createStream.mockImplementation((name) => {
       const newStream = createStreamMock();
       multiplexStreamMocks[name] = newStream;
@@ -171,7 +176,11 @@ describe('Desktop Connection', () => {
 
   describe('transferState', () => {
     it('writes state to state stream', async () => {
-      rawStateMock.getAndUpdateDesktopState.mockResolvedValueOnce(DATA_MOCK);
+      rawStateMock.getAndUpdateDesktopState.mockResolvedValueOnce(
+        DATA_MOCK as any,
+      );
+
+      rawStateMock.removePairingKey.mockReturnValueOnce(DATA_2_MOCK as any);
 
       await desktopConnection.createStream(
         remotePortMock,
@@ -185,7 +194,7 @@ describe('Desktop Connection', () => {
       await simulateTransferStateReceipt(promise);
 
       expect(stateStreamMock.write).toHaveBeenCalledTimes(1);
-      expect(stateStreamMock.write).toHaveBeenCalledWith(DATA_MOCK);
+      expect(stateStreamMock.write).toHaveBeenCalledWith(DATA_2_MOCK);
     });
   });
 

--- a/app/scripts/desktop/shared/pairing.ts
+++ b/app/scripts/desktop/shared/pairing.ts
@@ -3,6 +3,7 @@ import { Duplex } from 'stream';
 import EventEmitter from 'events';
 ///: END:ONLY_INCLUDE_IN
 import log from 'loglevel';
+import ObjectMultiplex from 'obj-multiplex';
 import TOTP from '../utils/totp';
 import {
   PairingKeyRequestMessage,
@@ -12,18 +13,38 @@ import {
 } from '../types/message';
 import * as rawState from '../utils/raw-state';
 import { browser } from '../browser/browser-polyfill';
-import { waitForMessage } from '../utils/stream';
+import {
+  acknowledge,
+  waitForAcknowledge,
+  waitForMessage,
+} from '../utils/stream';
 import { MESSAGE_ACKNOWLEDGE } from '../../../../shared/constants/desktop';
 import { createKey } from '../encryption/symmetric-encryption';
+import { hashString } from '../utils/crypto';
+
+const createStreams = (stream: Duplex) => {
+  const multiplex = new ObjectMultiplex();
+  const requestStream = multiplex.createStream('request');
+  const keyStream = multiplex.createStream('key');
+
+  stream.pipe(multiplex).pipe(stream);
+
+  return { requestStream, keyStream };
+};
 
 ///: BEGIN:ONLY_INCLUDE_IN(desktopextension)
 export class ExtensionPairing {
-  private stream: Duplex;
+  private requestStream: Duplex;
+
+  private keyStream: Duplex;
 
   private transferState: () => Promise<void>;
 
   constructor(stream: Duplex, transferState: () => Promise<void>) {
-    this.stream = stream;
+    const streams = createStreams(stream);
+
+    this.requestStream = streams.requestStream;
+    this.keyStream = streams.keyStream;
     this.transferState = transferState;
   }
 
@@ -34,58 +55,86 @@ export class ExtensionPairing {
   }
 
   public init() {
-    this.stream.on('data', (data: PairingRequestMessage) =>
-      this.onMessage(data),
-    );
+    this.requestStream.on('data', (data: PairingRequestMessage | string) => {
+      if (data === MESSAGE_ACKNOWLEDGE) {
+        return;
+      }
+
+      this.onRequestMessage(data as PairingRequestMessage);
+    });
+
     return this;
   }
 
   public async isPairingKeyMatch(): Promise<boolean> {
-    const extensionPairingKey = (await rawState.getDesktopState()).pairingKey;
+    log.debug('Validating pairing key');
+
     const requestPairingKey: PairingKeyRequestMessage = {
       isRequestPairingKey: true,
     };
-    this.stream.write(requestPairingKey);
 
-    // wait for desktop pairing key
+    this.keyStream.write(requestPairingKey);
+
+    // Wait for desktop pairing key
     const response = await waitForMessage<PairingKeyResponseMessage>(
-      this.stream,
+      this.keyStream,
     );
 
-    const isDesktopEnabled = extensionPairingKey === response.pairingKey;
+    const desktopPairingKey = response.pairingKey;
 
-    log.debug('Completed pairing key check', isDesktopEnabled);
-    return isDesktopEnabled as boolean;
+    if (!desktopPairingKey) {
+      log.debug('Desktop has no pairing key');
+      return false;
+    }
+
+    const desktopPairingKeyHash = await hashString(desktopPairingKey, {
+      isHex: true,
+    });
+
+    const extensionPairingKeyHash = (await rawState.getDesktopState())
+      .pairingKeyHash;
+
+    const isMatch = extensionPairingKeyHash === desktopPairingKeyHash;
+
+    log.debug('Completed pairing key check', isMatch);
+
+    return isMatch;
   }
 
-  private async onMessage(pairingRequestMessage: PairingRequestMessage) {
-    log.debug('Received pairing message', pairingRequestMessage);
+  private async onRequestMessage(pairingRequest: PairingRequestMessage) {
+    log.debug('Received pairing request message', pairingRequest);
 
-    const isValidOTP = TOTP.validate(pairingRequestMessage?.otp);
+    const isValidOTP = TOTP.validate(pairingRequest.otp);
 
     if (!isValidOTP) {
       log.debug('Received invalid OTP');
+
       const pairingResultMessage: PairingResultMessage = {
         isDesktopEnabled: false,
       };
-      this.stream.write(pairingResultMessage);
+
+      this.requestStream.write(pairingResultMessage);
       return;
     }
 
-    // Generate random pairing key and save it in state
+    const pairingKey = await createKey();
+    const pairingKeyHash = await hashString(pairingKey, { isHex: true });
+
     await rawState.setDesktopState({
       desktopEnabled: true,
-      pairingKey: await createKey(),
+      pairingKeyHash,
     });
 
     const pairingResultMessage: PairingResultMessage = {
       isDesktopEnabled: true,
+      pairingKey,
     };
-    this.stream.write(pairingResultMessage);
-    await waitForMessage(this.stream, (data) =>
-      Promise.resolve(data === MESSAGE_ACKNOWLEDGE),
-    );
-    log.debug('Saved pairing key');
+
+    this.requestStream.write(pairingResultMessage);
+
+    await waitForAcknowledge(this.requestStream);
+
+    log.debug('Saved pairing key', { pairingKey, pairingKeyHash });
 
     await this.transferState();
 
@@ -98,62 +147,69 @@ export class ExtensionPairing {
 
 ///: BEGIN:ONLY_INCLUDE_IN(desktopapp)
 export class DesktopPairing extends EventEmitter {
-  private stream: Duplex;
+  private requestStream: Duplex;
+
+  private keyStream: Duplex;
 
   constructor(stream: Duplex) {
     super();
-    this.stream = stream;
+
+    const streams = createStreams(stream);
+
+    this.requestStream = streams.requestStream;
+    this.keyStream = streams.keyStream;
   }
 
   public init() {
-    this.stream.on('data', (data: PairingResultMessage) =>
-      this.onMessage(data),
+    this.requestStream.on('data', (data: PairingResultMessage) =>
+      this.onRequestMessage(data),
     );
+
+    this.keyStream.on('data', (data: PairingKeyRequestMessage) =>
+      this.onKeyMessage(data),
+    );
+
     return this;
   }
 
   public async submitOTP(otp: string) {
     log.debug('Received OTP', otp);
-    this.stream.write({ otp });
+    this.requestStream.write({ otp });
   }
 
-  private async onPairingKeyRequestMessage(
-    pairingKeyRequestMessage: PairingKeyRequestMessage,
-  ) {
-    log.debug('Received pairing key request message', pairingKeyRequestMessage);
+  private async onRequestMessage(pairingResult: PairingResultMessage) {
+    log.debug('Received pairing request response', pairingResult);
+
+    if (!pairingResult.isDesktopEnabled) {
+      log.debug('Submitted OTP was invalid');
+      this.emit('invalid-otp', false);
+      return;
+    }
+
+    const { pairingKey } = pairingResult;
+
+    await rawState.setDesktopState({
+      desktopEnabled: true,
+      pairingKey,
+    });
+
+    log.debug('Saved pairing key', pairingKey);
+
+    acknowledge(this.requestStream);
+  }
+
+  private async onKeyMessage(_: PairingKeyRequestMessage) {
+    log.debug('Received pairing key request');
+
     const desktopPairingKey = (await rawState.getDesktopState()).pairingKey;
-    log.debug('Comparing desktop and extension pairing keys');
 
     const response: PairingKeyResponseMessage = {
       pairingKey: desktopPairingKey,
     };
-    this.stream.write(response);
-  }
 
-  private async onMessage(
-    pairingMessage: PairingResultMessage | PairingKeyRequestMessage,
-  ) {
-    log.debug('Received pairing message', pairingMessage);
+    log.debug('Sending pairing key response', response);
 
-    if (this.isPairingKeyRequestMessage(pairingMessage)) {
-      await this.onPairingKeyRequestMessage(pairingMessage);
-      return;
-    }
-
-    if ((pairingMessage as PairingResultMessage)?.isDesktopEnabled) {
-      await rawState.setDesktopState({ desktopEnabled: true });
-      this.stream.write(MESSAGE_ACKNOWLEDGE);
-      return;
-    }
-
-    log.debug('Submitted OTP was invalid');
-    this.emit('invalid-otp', false);
-  }
-
-  private isPairingKeyRequestMessage(
-    msg: PairingResultMessage | PairingKeyRequestMessage,
-  ): msg is PairingKeyRequestMessage {
-    return (msg as PairingKeyRequestMessage)?.isRequestPairingKey !== undefined;
+    this.keyStream.write(response);
   }
 }
 ///: END:ONLY_INCLUDE_IN

--- a/app/scripts/desktop/shared/pairing.ts
+++ b/app/scripts/desktop/shared/pairing.ts
@@ -3,6 +3,8 @@ import { Duplex } from 'stream';
 import EventEmitter from 'events';
 ///: END:ONLY_INCLUDE_IN
 import log from 'loglevel';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 import ObjectMultiplex from 'obj-multiplex';
 import TOTP from '../utils/totp';
 import {

--- a/app/scripts/desktop/test/mocks.ts
+++ b/app/scripts/desktop/test/mocks.ts
@@ -51,6 +51,11 @@ export const UUID_MOCK = '6328e6ae-f867-4876-af6f-22a44efbe251';
 export const OTP_MOCK = '123456';
 export const VERSION_MOCK = '123.456.789.012';
 export const VERSION_2_MOCK = '456.123.789.012';
+export const HASH_BUFFER_MOCK = Buffer.from([10, 11, 12]);
+export const HASH_BUFFER_2_MOCK = Buffer.from([10, 11, 13]);
+export const IV_HEX_MOCK = Buffer.from(IV_BUFFER_MOCK).toString('hex');
+export const HASH_BUFFER_HEX_MOCK = HASH_BUFFER_MOCK.toString('hex');
+export const HASH_BUFFER_2_HEX_MOCK = HASH_BUFFER_2_MOCK.toString('hex');
 
 export const EXPORTED_KEY_HEX_MOCK =
   Buffer.from(EXPORTED_KEY_MOCK).toString('hex');
@@ -58,8 +63,6 @@ export const EXPORTED_KEY_HEX_MOCK =
 export const ENCRYPTED_HEX_MOCK = Buffer.from(ENCRYPTED_BUFFER_MOCK).toString(
   'hex',
 );
-
-export const IV_HEX_MOCK = Buffer.from(IV_BUFFER_MOCK).toString('hex');
 
 export const NEW_CONNECTION_MESSAGE_MOCK = {
   clientId: CLIENT_ID_MOCK,

--- a/app/scripts/desktop/test/mocks.ts
+++ b/app/scripts/desktop/test/mocks.ts
@@ -12,7 +12,7 @@ import {
 } from '../shared/web-socket-stream';
 import ExtensionConnection from '../app/extension-connection';
 import DesktopConnection from '../extension/desktop-connection';
-import { ExtensionPairing } from '../shared/pairing';
+import { DesktopPairing, ExtensionPairing } from '../shared/pairing';
 import { TestConnectionResult } from '../types/desktop';
 import { ExtensionVersionCheck } from '../shared/version-check';
 import ExtensionPlatform from 'app/scripts/platforms/extension';
@@ -144,7 +144,7 @@ export const createMultiplexMock = (): jest.Mocked<ObjectMultiplex & Duplex> =>
   ({
     ...createStreamMock(),
     createStream: jest.fn(),
-  } as unknown as jest.Mocked<ObjectMultiplex>);
+  } as any);
 
 export const createEventEmitterMock = (): jest.Mocked<EventEmitter> =>
   ({
@@ -198,3 +198,6 @@ export const createExtensionVersionCheckMock =
 
 export const createExtensionPlatformMock = (): jest.Mocked<ExtensionPlatform> =>
   ({ getVersion: jest.fn() } as any);
+
+export const createDesktopPairingMock = (): jest.Mocked<DesktopPairing> =>
+  ({ init: jest.fn() } as any);

--- a/app/scripts/desktop/types/background.ts
+++ b/app/scripts/desktop/types/background.ts
@@ -16,8 +16,6 @@ export interface RemotePort extends RemotePortData {
 
 export type ConnectRemoteFactory = (remotePort: RemotePort) => undefined;
 
-export type State = any;
-
 export enum ConnectionType {
   INTERNAL = 'INTERNAL',
   EXTERNAL = 'EXTERNAL',

--- a/app/scripts/desktop/types/desktop.ts
+++ b/app/scripts/desktop/types/desktop.ts
@@ -3,6 +3,14 @@ export type ClientId = string;
 export interface DesktopState {
   desktopEnabled?: boolean;
   pairingKey?: string;
+  pairingKeyHash?: string;
+}
+
+export interface RawState {
+  data: {
+    DesktopController: DesktopState;
+    [otherOptions: string]: unknown;
+  };
 }
 
 export interface VersionCheckResult {

--- a/app/scripts/desktop/types/message.ts
+++ b/app/scripts/desktop/types/message.ts
@@ -29,6 +29,7 @@ export type PairingRequestMessage = {
 
 export type PairingResultMessage = {
   isDesktopEnabled: boolean;
+  pairingKey?: string;
 };
 
 export type PairingKeyRequestMessage = {

--- a/app/scripts/desktop/utils/crypto.test.ts
+++ b/app/scripts/desktop/utils/crypto.test.ts
@@ -1,0 +1,57 @@
+import {
+  HASH_BUFFER_HEX_MOCK,
+  HASH_BUFFER_MOCK,
+  IV_BUFFER_MOCK,
+  STRING_DATA_MOCK,
+} from '../test/mocks';
+import { hashString, randomHex } from './crypto';
+
+describe('Crypto Utils', () => {
+  const cryptoMock = {
+    getRandomValues: jest.fn(),
+    subtle: {
+      digest: jest.fn(),
+    },
+  } as any;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.spyOn(global, 'crypto', 'get').mockImplementation(() => cryptoMock);
+  });
+
+  describe('randomHex', () => {
+    it('returns random hex', () => {
+      cryptoMock.getRandomValues.mockReturnValueOnce(IV_BUFFER_MOCK);
+      const result = randomHex();
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('hashString', () => {
+    it('returns hex of hash from global crypto object', async () => {
+      cryptoMock.subtle.digest.mockResolvedValueOnce(HASH_BUFFER_MOCK);
+
+      const result = await hashString(STRING_DATA_MOCK);
+
+      expect(result).toStrictEqual(HASH_BUFFER_HEX_MOCK);
+
+      expect(cryptoMock.subtle.digest).toHaveBeenCalledTimes(1);
+      expect(cryptoMock.subtle.digest).toHaveBeenCalledWith(
+        'SHA-512',
+        Buffer.from(STRING_DATA_MOCK, 'utf8'),
+      );
+    });
+
+    it('uses hex buffer if isHex true', async () => {
+      cryptoMock.subtle.digest.mockResolvedValueOnce(HASH_BUFFER_MOCK);
+
+      await hashString(STRING_DATA_MOCK, { isHex: true });
+
+      expect(cryptoMock.subtle.digest).toHaveBeenCalledTimes(1);
+      expect(cryptoMock.subtle.digest).toHaveBeenCalledWith(
+        'SHA-512',
+        Buffer.from(STRING_DATA_MOCK, 'hex'),
+      );
+    });
+  });
+});

--- a/app/scripts/desktop/utils/crypto.ts
+++ b/app/scripts/desktop/utils/crypto.ts
@@ -1,3 +1,9 @@
+export const randomHex = (): string => {
+  const random =
+    global.crypto?.getRandomValues(new Uint8Array(12)) || Buffer.from([]);
+  return Buffer.from(random).toString('hex');
+};
+
 export const hashString = async (
   dataString: string,
   { isHex = false } = {},

--- a/app/scripts/desktop/utils/crypto.ts
+++ b/app/scripts/desktop/utils/crypto.ts
@@ -1,0 +1,16 @@
+export const hashString = async (
+  dataString: string,
+  { isHex = false } = {},
+) => {
+  const encoding = isHex ? 'hex' : 'utf8';
+  const dataBuffer = Buffer.from(dataString, encoding);
+
+  const hashArrayBuffer = await global.crypto.subtle.digest(
+    'SHA-512',
+    dataBuffer,
+  );
+
+  const hashBuffer = Buffer.from(hashArrayBuffer);
+
+  return hashBuffer.toString('hex');
+};

--- a/app/scripts/desktop/utils/raw-state.ts
+++ b/app/scripts/desktop/utils/raw-state.ts
@@ -1,7 +1,7 @@
 import { browser } from '../browser/browser-polyfill';
-import { DesktopState } from '../types/desktop';
+import { DesktopState, RawState } from '../types/desktop';
 
-export const get = async (): Promise<any> => {
+export const get = async (): Promise<RawState> => {
   return await browser.storage.local.get();
 };
 
@@ -12,7 +12,7 @@ export const getDesktopState = async (): Promise<DesktopState> => {
 
 export const getAndUpdateDesktopState = async (
   desktopState: DesktopState,
-): Promise<any> => {
+): Promise<RawState> => {
   const state = await get();
   const currentDesktopState = state.data.DesktopController;
 
@@ -21,7 +21,7 @@ export const getAndUpdateDesktopState = async (
   return state;
 };
 
-export const set = async (state: any) => {
+export const set = async (state: RawState) => {
   await browser.storage.local.set(state);
 };
 
@@ -32,4 +32,34 @@ export const setDesktopState = async (desktopState: DesktopState) => {
 
 export const clear = async () => {
   await browser.storage.local.clear();
+};
+
+export const addPairingKey = async (state: RawState): Promise<RawState> => {
+  const existingDeskotpState = await getDesktopState();
+
+  return {
+    ...state,
+    data: {
+      ...state.data,
+      DesktopController: {
+        ...state.data?.DesktopController,
+        pairingKey: existingDeskotpState.pairingKey,
+        pairingKeyHash: existingDeskotpState.pairingKeyHash,
+      },
+    },
+  };
+};
+
+export const removePairingKey = (state: RawState) => {
+  return {
+    ...state,
+    data: {
+      ...state.data,
+      DesktopController: {
+        ...state.data.DesktopController,
+        pairingKey: undefined,
+        pairingKeyHash: undefined,
+      },
+    },
+  };
 };

--- a/app/scripts/desktop/utils/stream.ts
+++ b/app/scripts/desktop/utils/stream.ts
@@ -1,4 +1,5 @@
-import { Duplex, Readable } from 'stream';
+import { Duplex, Readable, Writable } from 'stream';
+import { MESSAGE_ACKNOWLEDGE } from '../../../../shared/constants/desktop';
 
 export const waitForMessage = <T>(
   stream: Readable,
@@ -17,6 +18,16 @@ export const waitForMessage = <T>(
 
     stream.on('data', listener);
   });
+};
+
+export const waitForAcknowledge = async (stream: Readable) => {
+  await waitForMessage(stream, (data) =>
+    Promise.resolve(data === MESSAGE_ACKNOWLEDGE),
+  );
+};
+
+export const acknowledge = (stream: Writable) => {
+  stream.write(MESSAGE_ACKNOWLEDGE);
 };
 
 export class DuplexCopy extends Duplex {

--- a/app/scripts/desktop/utils/totp.ts
+++ b/app/scripts/desktop/utils/totp.ts
@@ -1,5 +1,5 @@
 import * as OTPAuth from 'otpauth';
-import { randomHex } from './utils';
+import { randomHex } from './crypto';
 
 class TOTP {
   private static instance: OTPAuth.TOTP;

--- a/app/scripts/desktop/utils/utils.test.ts
+++ b/app/scripts/desktop/utils/utils.test.ts
@@ -1,12 +1,11 @@
 import {
   DATA_MOCK,
-  IV_BUFFER_MOCK,
   METHOD_MOCK,
   RESULT_MOCK,
   STREAM_MOCK,
   TYPE_MOCK,
 } from '../test/mocks';
-import { flattenMessage, randomHex } from './utils';
+import { flattenMessage } from './utils';
 
 describe('Desktop Utils', () => {
   describe('flattenMessage', () => {
@@ -56,25 +55,6 @@ describe('Desktop Utils', () => {
         method: METHOD_MOCK,
         isResult: true,
       });
-    });
-  });
-
-  describe('randomHex', () => {
-    let cryptoMock: jest.Mocked<Crypto>;
-    beforeEach(() => {
-      jest.resetAllMocks();
-
-      cryptoMock = {
-        getRandomValues: jest.fn(),
-      } as any;
-
-      jest.spyOn(global, 'crypto', 'get').mockImplementation(() => cryptoMock);
-    });
-
-    it('returns random hex', () => {
-      cryptoMock.getRandomValues.mockReturnValueOnce(IV_BUFFER_MOCK);
-      const result = randomHex();
-      expect(result).toBeDefined();
     });
   });
 });

--- a/app/scripts/desktop/utils/utils.ts
+++ b/app/scripts/desktop/utils/utils.ts
@@ -51,9 +51,3 @@ export const timeoutPromise = <T>(
 };
 
 export const uuid = uuidv4;
-
-export const randomHex = (): string => {
-  const random =
-    global.crypto?.getRandomValues(new Uint8Array(12)) || Buffer.from([]);
-  return Buffer.from(random).toString('hex');
-};


### PR DESCRIPTION
# Overview

Store only a hash of the pairing key in the extension to prevent it from being extracted and used to bypass the pairing process.

# Changes

## Desktop

- Explicitly update the desktop state after pairing using the pairing key from the result message.
- Prevent the pairing key being transferred to the extension during state synchronisation.

## Extension

- Store only a hash of the pairing key in the desktop controller state.
- Hash the pairing key received from the desktop and compare it to the persisted pairing key hash.
- Include the pairing key in the pairing result message.
- Prevent the pairing key hash being transferred to the desktop during state synchronisation.

## Other

- Use a multiplex in the pairing classes to more easily differentiate request and key messages.
- Create the `RawState` type to avoid using `any` when dealing with raw state.
- Create a file for crypto based utils including a new `hashString` function and the existing `randomHex` function.
- Encapsulate all acknowledge message logic using new `waitForAcknowledge` and `acknowledge` functions.