### PR TITLE
Protecting pairing flow limiting otp attempts

### DIFF
--- a/packages/app/app/scripts/desktop/test/mocks.ts
+++ b/packages/app/app/scripts/desktop/test/mocks.ts
@@ -49,6 +49,7 @@ export const JSON_RPC_ID_MOCK = 123456;
 export const ARGS_MOCK = ['test123', 123, true];
 export const UUID_MOCK = '6328e6ae-f867-4876-af6f-22a44efbe251';
 export const OTP_MOCK = '123456';
+export const WRONG_OTP_MOCK = '654321';
 export const VERSION_MOCK = '123.456.789.012';
 export const VERSION_2_MOCK = '456.123.789.012';
 export const HASH_BUFFER_MOCK = Buffer.from([10, 11, 12]);

--- a/packages/app/app/scripts/desktop/utils/totp.test.ts
+++ b/packages/app/app/scripts/desktop/utils/totp.test.ts
@@ -1,10 +1,11 @@
 import { TOTP as TOTPAuth } from 'otpauth';
-import { OTP_MOCK } from '../test/mocks';
+import { OTP_MOCK, WRONG_OTP_MOCK } from '../test/mocks';
 import TOTP from './totp';
 
 describe('TOTP', () => {
   let validateMock;
   let generateMock;
+  let initMock;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -12,6 +13,7 @@ describe('TOTP', () => {
     generateMock = jest
       .spyOn(TOTPAuth, 'generate')
       .mockImplementation(() => OTP_MOCK);
+    initMock = jest.spyOn(TOTP as any, 'init');
   });
 
   it('generates OTP', async () => {
@@ -35,5 +37,14 @@ describe('TOTP', () => {
       secret: expect.anything(),
       timestamp: undefined,
     });
+  });
+
+  it('resets TOTP instance after exceed the max attempts within 30 seconds', async () => {
+    for (let i = 0; i < 10; i++) {
+      TOTP.validate(WRONG_OTP_MOCK);
+      expect(validateMock).toHaveBeenCalled();
+    }
+    expect(validateMock).toHaveBeenCalledTimes(10);
+    expect(initMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/app/scripts/desktop/utils/totp.ts
+++ b/packages/app/app/scripts/desktop/utils/totp.ts
@@ -25,14 +25,14 @@ class TOTP {
 
     // Increase attempts counter
     TOTP.validateAttemptsCounter += 1;
-    if (this.isMaxValidateAttemptsReach(TOTP.validateAttemptsCounter)) {
+    if (this.hasReachedMaxValidateAttempts(TOTP.validateAttemptsCounter)) {
       this.init({ resetInstance: true });
     }
 
     return result !== null;
   };
 
-  private isMaxValidateAttemptsReach = (counter: number): boolean => {
+  private hasReachedMaxValidateAttempts = (counter: number): boolean => {
     return counter >= MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS;
   };
 


### PR DESCRIPTION
# Overview
Protecting pairing flow limits max OTP attempts to 10. If attempts surpass it a new instance of TOTP is created with a new secret and the correct TOTP generated by the extension is disregarded.

# Changes
## Desktop
* None


## Extension
* added a private method `init` allowing the possibility to `resetInstance` if `MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS` are reached.

## Issues
Resolves https://github.com/MetaMask/desktop/issues/200