### PR TITLE
Fix windows build and certificate

### DIFF
--- a/packages/app/desktop_packaging/windows/generate_certificate.ps1
+++ b/packages/app/desktop_packaging/windows/generate_certificate.ps1
@@ -16,5 +16,5 @@ $password = ConvertTo-SecureString `
 
 Export-PfxCertificate `
     -Cert "Cert:\CurrentUser\My\$($certificate.Thumbprint)" `
-    -FilePath "packages/app/desktop_packaging/windows/test_certificate.pfx" `
+    -FilePath "desktop_packaging/windows/test_certificate.pfx" `
     -Password $password

--- a/packages/app/desktop_packaging/windows/generate_certificate.ps1
+++ b/packages/app/desktop_packaging/windows/generate_certificate.ps1
@@ -16,5 +16,5 @@ $password = ConvertTo-SecureString `
 
 Export-PfxCertificate `
     -Cert "Cert:\CurrentUser\My\$($certificate.Thumbprint)" `
-    -FilePath "desktop_packaging/windows/test_certificate.pfx" `
+    -FilePath "packages/app/desktop_packaging/windows/test_certificate.pfx" `
     -Password $password

--- a/packages/app/development/desktop/electron/build/static.js
+++ b/packages/app/development/desktop/electron/build/static.js
@@ -64,7 +64,10 @@ module.exports = function createStaticAssetTasks({
   }
 
   async function copyGlob(baseDir, srcGlob, dest) {
-    const sources = await glob(srcGlob, { onlyFiles: false });
+    const fixedSrcGlob =
+      process.platform === 'win32' ? srcGlob.replace(/\\/gu, '/') : srcGlob;
+
+    const sources = await glob(fixedSrcGlob, { onlyFiles: false });
     await Promise.all(
       sources.map(async (src) => {
         const relativePath = path.relative(baseDir, src);


### PR DESCRIPTION
Quick fixes for:
- Making sure that static files are copied correctly in windows (copied from extension script)
- Path to generate self-signed certificate is correct.