### PR TITLE
Fix background and window buttons of title bar in Windows

### DIFF
--- a/packages/app/app/scripts/desktop/app/desktop-app.ts
+++ b/packages/app/app/scripts/desktop/app/desktop-app.ts
@@ -13,6 +13,7 @@ import * as RawState from '../utils/raw-state';
 import { MILLISECOND } from '../../../../shared/constants/time';
 import ExtensionConnection from './extension-connection';
 import { updateCheck } from './update-check';
+import { titleBarOverlayOpts } from './ui-constants';
 
 const MAIN_WINDOW_SHOW_DELAY = 750 * MILLISECOND;
 
@@ -70,6 +71,11 @@ class DesktopApp extends EventEmitter {
     ipcMain.handle('reset', async (_event) => {
       await RawState.clear();
       this.status.isDesktopEnabled = false;
+    });
+
+    ipcMain.handle('set-theme', (event, theme) => {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      win?.setTitleBarOverlay(titleBarOverlayOpts[theme]);
     });
 
     if (!cfg().desktop.isTest) {
@@ -213,10 +219,8 @@ class DesktopApp extends EventEmitter {
     const mainWindow = new BrowserWindow({
       width: 800,
       height: 640,
-      vibrancy: 'dark',
       titleBarStyle: 'hidden',
-      visualEffectState: 'active',
-      show: false,
+      titleBarOverlay: titleBarOverlayOpts.light,
       webPreferences: {
         preload: path.resolve(__dirname, './status-preload.js'),
         nodeIntegration: true,
@@ -227,6 +231,9 @@ class DesktopApp extends EventEmitter {
         '../../../../../dist_desktop_ui/images/icon-128.png',
       ),
     });
+
+    // Keep this to prevent "alt" key is not triggering menu in Windows
+    mainWindow?.setMenu(null);
 
     mainWindow.loadFile(
       path.resolve(__dirname, '../../../../../dist_desktop_ui/desktop-ui.html'),

--- a/packages/app/app/scripts/desktop/app/ui-constants.ts
+++ b/packages/app/app/scripts/desktop/app/ui-constants.ts
@@ -1,0 +1,14 @@
+import { THEME_TYPE } from '../../../../ui/desktop/helpers/constants/themeIndex';
+
+export const titleBarOverlayOpts = {
+  [THEME_TYPE.DARK]: {
+    color: '#24272a',
+    symbolColor: '#FFFFFF',
+    height: 32,
+  },
+  [THEME_TYPE.LIGHT]: {
+    color: '#ffffff',
+    symbolColor: '#000000',
+    height: 32,
+  },
+};

--- a/packages/app/test/jest/setup.js
+++ b/packages/app/test/jest/setup.js
@@ -19,3 +19,6 @@ beforeEach(() => {
 
 // Disable the test flag in desktop unit tests as this is only used for E2E tests
 cfg().desktop.isTest = false;
+
+// Electron supplies window.require but it isn't defined when running unit tests with Jest
+window.require = require;

--- a/packages/app/ui/desktop/ducks/index.js
+++ b/packages/app/ui/desktop/ducks/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import { persistReducer } from 'redux-persist';
 
 import createElectronStorage from '../helpers/utils/electron-storage';
+import { persistedUIStoreKey } from '../helpers/constants/storage';
 import appReducer from './app/app';
 import localesReducer from './locale/locale';
 import pairStatusReducer from './pair-status/pair-status';
@@ -27,8 +28,7 @@ const rootReducer = combineReducers({
 const rootPersistConfig = {
   key: 'root',
   storage: createElectronStorage({
-    // Change the number to clear the storage
-    name: 'mmd-desktop-ui-v0.0.0-root',
+    name: persistedUIStoreKey,
   }),
   whitelist: ['app', 'locales'],
 };

--- a/packages/app/ui/desktop/helpers/constants/storage.js
+++ b/packages/app/ui/desktop/helpers/constants/storage.js
@@ -1,0 +1,2 @@
+// Change the number to clear the storage
+export const persistedUIStoreKey = 'mmd-desktop-ui-v0.0.0-root';

--- a/packages/app/ui/desktop/helpers/utils/theme.js
+++ b/packages/app/ui/desktop/helpers/utils/theme.js
@@ -1,18 +1,27 @@
 import { THEME_TYPE } from '../../../pages/settings/settings-tab/settings-tab.constant';
 
-const handleOSTheme = () => {
-  const osTheme = window?.matchMedia('(prefers-color-scheme: dark)')?.matches
+const { ipcRenderer } = window.require('electron');
+
+const getOSTheme = () => {
+  return window?.matchMedia('(prefers-color-scheme: dark)')?.matches
     ? THEME_TYPE.DARK
     : THEME_TYPE.LIGHT;
+};
+
+const handleOSTheme = () => {
+  const osTheme = getOSTheme();
   document.documentElement.setAttribute('data-theme', osTheme);
 };
 
 const setTheme = (theme) => {
+  let themeCode = theme;
   if (theme === THEME_TYPE.OS) {
     handleOSTheme();
+    themeCode = getOSTheme();
   } else {
     document.documentElement.setAttribute('data-theme', theme);
   }
+  ipcRenderer.invoke('set-theme', themeCode);
 };
 
 export default setTheme;

--- a/packages/app/ui/desktop/mmd.scss
+++ b/packages/app/ui/desktop/mmd.scss
@@ -1,3 +1,5 @@
+$title-bar-height: 32px;
+
 body {
   background-color: var(--color-background-default);
 }
@@ -6,7 +8,7 @@ body {
   height: 100%;
   width: 100%;
   overflow-y: scroll;
-  padding-top: 30px;
+  padding-top: $title-bar-height;
 }
 
 #mmd-app-content {
@@ -15,11 +17,12 @@ body {
 }
 
 #mmd-draggable-hidden-bar {
-  height: 30px;
+  height: $title-bar-height;
   width: 100%;
   -webkit-app-region: drag;
   position: fixed;
   top: 0;
+  background-color: var(--color-background-default);
 }
 
 @import './pages/mmd-pages.scss';

--- a/packages/app/ui/desktop/pages/routes/routes.component.js
+++ b/packages/app/ui/desktop/pages/routes/routes.component.js
@@ -16,7 +16,7 @@ const Routes = ({ theme }) => {
   useEffect(() => {
     // Set theme (html attr) for the first time
     setTheme(theme);
-  }, [theme]);
+  }, []);
 
   return (
     <div id="mmd-app-content">


### PR DESCRIPTION
## Overview
Fixes and put background color in to draggable top bar to desktop UI

### Notes
* Frameless window setting is removed due to issues on Windows window buttons (minimize, full-screen, close)
* To adapt window button background colors due to theme changes, `set-theme` event was added in to initialisation of desktop app

![Screenshot 2022-11-21 at 17 37 45](https://user-images.githubusercontent.com/7644512/203110548-75aef8b1-1615-4d67-82a5-f98d4f164860.png)
![Screenshot 2022-11-21 at 17 38 03](https://user-images.githubusercontent.com/7644512/203110612-1b2c0568-e22d-4c10-a252-0b93c3fe6303.png)

