### PR TITLE
fix: close connection when pairing key does not match

### DIFF
--- a/packages/app/src/extension/desktop-connection.test.ts
+++ b/packages/app/src/extension/desktop-connection.test.ts
@@ -239,11 +239,11 @@ describe('Desktop Connection', () => {
   describe('checkPairingKey', () => {
     it('invokes pairing key check instance', async () => {
       extensionPairingMock.checkPairingKeyMatch.mockImplementation(
-        async () => PairingKeyStatus.pairingKeyMatch,
+        async () => PairingKeyStatus.MATCH,
       );
 
       expect(await desktopConnection.checkPairingKey()).toBe(
-        PairingKeyStatus.pairingKeyMatch,
+        PairingKeyStatus.MATCH,
       );
 
       expect(extensionPairingMock.checkPairingKeyMatch).toHaveBeenCalledTimes(

--- a/packages/app/src/extension/desktop-connection.test.ts
+++ b/packages/app/src/extension/desktop-connection.test.ts
@@ -8,7 +8,11 @@ import {
   CLIENT_ID_DISABLE,
   MESSAGE_ACKNOWLEDGE,
 } from '@metamask/desktop/dist/constants';
-import { ConnectionType, ClientId } from '@metamask/desktop/dist/types';
+import {
+  ConnectionType,
+  ClientId,
+  PairingKeyStatus,
+} from '@metamask/desktop/dist/types';
 import * as RawStateUtils from '@metamask/desktop/dist/utils/state';
 import { VersionCheck } from '@metamask/desktop/dist/version-check';
 import { uuid } from '@metamask/desktop/dist/utils/utils';
@@ -234,11 +238,15 @@ describe('Desktop Connection', () => {
 
   describe('checkPairingKey', () => {
     it('invokes pairing key check instance', async () => {
-      extensionPairingMock.isPairingKeyMatch.mockImplementation(
-        async () => true,
+      extensionPairingMock.checkPairingKeyMatch.mockImplementation(
+        async () => PairingKeyStatus.pairingKeyMatch,
       );
-      expect(await desktopConnection.checkPairingKey()).toBe(true);
-      expect(extensionPairingMock.isPairingKeyMatch).toHaveBeenCalledTimes(1);
+      expect(await desktopConnection.checkPairingKey()).toBe(
+        PairingKeyStatus.pairingKeyMatch,
+      );
+      expect(extensionPairingMock.checkPairingKeyMatch).toHaveBeenCalledTimes(
+        1,
+      );
     });
   });
 

--- a/packages/app/src/extension/desktop-connection.test.ts
+++ b/packages/app/src/extension/desktop-connection.test.ts
@@ -241,9 +241,11 @@ describe('Desktop Connection', () => {
       extensionPairingMock.checkPairingKeyMatch.mockImplementation(
         async () => PairingKeyStatus.pairingKeyMatch,
       );
+
       expect(await desktopConnection.checkPairingKey()).toBe(
         PairingKeyStatus.pairingKeyMatch,
       );
+
       expect(extensionPairingMock.checkPairingKeyMatch).toHaveBeenCalledTimes(
         1,
       );

--- a/packages/app/src/extension/desktop-connection.ts
+++ b/packages/app/src/extension/desktop-connection.ts
@@ -25,6 +25,7 @@ import {
   RawState,
   VersionCheckResult,
   RemotePort,
+  PairingKeyStatus,
 } from '@metamask/desktop/dist/types';
 import {
   addPairingKeyToRawState,
@@ -144,8 +145,8 @@ export default class DesktopConnection extends EventEmitter {
     return await this.versionCheck.check();
   }
 
-  public async checkPairingKey(): Promise<boolean> {
-    return await this.extensionPairing.isPairingKeyMatch();
+  public async checkPairingKey(): Promise<PairingKeyStatus> {
+    return await this.extensionPairing.checkPairingKeyMatch();
   }
 
   private async onDisable(state: RawState) {
@@ -158,6 +159,7 @@ export default class DesktopConnection extends EventEmitter {
       await setDesktopState({
         desktopEnabled: false,
         pairingKey: undefined,
+        pairingKeyHash: undefined,
       });
       log.debug('Disabled desktop mode');
     }

--- a/packages/app/src/extension/desktop-manager.test.ts
+++ b/packages/app/src/extension/desktop-manager.test.ts
@@ -212,6 +212,7 @@ describe('Desktop Manager', () => {
         rawStateMock.getDesktopState.mockResolvedValueOnce({
           desktopEnabled,
         });
+
         DesktopManager.setState({
           DesktopController: { desktopEnabled },
         });
@@ -299,6 +300,7 @@ describe('Desktop Manager', () => {
       desktopConnectionMock.checkPairingKey.mockResolvedValue(
         PairingKeyStatus.pairingKeyMatch,
       );
+
       rawStateMock.getDesktopState.mockResolvedValueOnce({
         desktopEnabled: true,
       });

--- a/packages/app/src/extension/desktop-manager.test.ts
+++ b/packages/app/src/extension/desktop-manager.test.ts
@@ -209,6 +209,9 @@ describe('Desktop Manager', () => {
     it.each([{ desktopEnabled: true }, { desktopEnabled: false }])(
       'returns $desktopEnabled if desktop state contains desktop enabled as $desktopEnabled',
       async ({ desktopEnabled }) => {
+        rawStateMock.getDesktopState.mockResolvedValueOnce({
+          desktopEnabled,
+        });
         DesktopManager.setState({
           DesktopController: { desktopEnabled },
         });

--- a/packages/app/src/extension/desktop-manager.test.ts
+++ b/packages/app/src/extension/desktop-manager.test.ts
@@ -187,7 +187,7 @@ describe('Desktop Manager', () => {
 
     it('creates connection if desktop state enabled and no existing connection', async () => {
       desktopConnectionMock.checkPairingKey.mockResolvedValue(
-        PairingKeyStatus.pairingKeyMatch,
+        PairingKeyStatus.MATCH,
       );
       DesktopManager.setState({ DesktopController: { desktopEnabled: true } });
 
@@ -298,7 +298,7 @@ describe('Desktop Manager', () => {
   describe('on disconnect', () => {
     beforeEach(async () => {
       desktopConnectionMock.checkPairingKey.mockResolvedValue(
-        PairingKeyStatus.pairingKeyMatch,
+        PairingKeyStatus.MATCH,
       );
 
       rawStateMock.getDesktopState.mockResolvedValueOnce({

--- a/packages/app/src/extension/desktop-manager.test.ts
+++ b/packages/app/src/extension/desktop-manager.test.ts
@@ -4,6 +4,7 @@ import { browser } from '@metamask/desktop/dist/browser';
 import {
   TestConnectionResult,
   ConnectionType,
+  PairingKeyStatus,
 } from '@metamask/desktop/dist/types';
 import { WebSocketStream } from '@metamask/desktop/dist/web-socket-stream';
 import { cfg } from '@metamask/desktop/dist/utils/config';
@@ -185,7 +186,9 @@ describe('Desktop Manager', () => {
     });
 
     it('creates connection if desktop state enabled and no existing connection', async () => {
-      desktopConnectionMock.checkPairingKey.mockResolvedValue(true);
+      desktopConnectionMock.checkPairingKey.mockResolvedValue(
+        PairingKeyStatus.pairingKeyMatch,
+      );
       DesktopManager.setState({ DesktopController: { desktopEnabled: true } });
 
       expect(await initDesktopManager(DesktopManager.getConnection())).toBe(
@@ -290,7 +293,9 @@ describe('Desktop Manager', () => {
 
   describe('on disconnect', () => {
     beforeEach(async () => {
-      desktopConnectionMock.checkPairingKey.mockResolvedValue(true);
+      desktopConnectionMock.checkPairingKey.mockResolvedValue(
+        PairingKeyStatus.pairingKeyMatch,
+      );
       rawStateMock.getDesktopState.mockResolvedValueOnce({
         desktopEnabled: true,
       });

--- a/packages/app/src/extension/desktop-manager.ts
+++ b/packages/app/src/extension/desktop-manager.ts
@@ -8,7 +8,6 @@ import {
   DesktopState,
   TestConnectionResult,
   ConnectionType,
-  PairingKeyStatus,
 } from '@metamask/desktop/dist/types';
 import {
   BrowserWebSocket,
@@ -60,11 +59,8 @@ class DesktopManager {
     return this.desktopConnection;
   }
 
-  public async isDesktopEnabled(): Promise<boolean> {
-    return (
-      this.desktopState.desktopEnabled === true ||
-      (await RawState.getDesktopState())?.desktopEnabled === true
-    );
+  public isDesktopEnabled(): boolean {
+    return this.desktopState.desktopEnabled === true;
   }
 
   public async createStream(remotePort: any, connectionType: ConnectionType) {
@@ -127,13 +123,10 @@ class DesktopManager {
 
     log.debug('Created web socket connection');
 
-    if (!cfg().skipOtpPairingFlow && (await this.isDesktopEnabled())) {
+    if (!cfg().skipOtpPairingFlow && this.isDesktopEnabled()) {
       log.debug('Desktop enabled, checking pairing key');
 
-      if (
-        (await connection.checkPairingKey()) !==
-        PairingKeyStatus.pairingKeyMatch
-      ) {
+      if (await connection.checkPairingKey()) {
         log.error('Desktop app not recognized');
         webSocket.close();
         throw new Error('Desktop app not recognized');

--- a/packages/app/src/extension/desktop-manager.ts
+++ b/packages/app/src/extension/desktop-manager.ts
@@ -8,6 +8,7 @@ import {
   DesktopState,
   TestConnectionResult,
   ConnectionType,
+  PairingKeyStatus,
 } from '@metamask/desktop/dist/types';
 import {
   BrowserWebSocket,
@@ -126,7 +127,12 @@ class DesktopManager {
     if (!cfg().skipOtpPairingFlow && this.isDesktopEnabled()) {
       log.debug('Desktop enabled, checking pairing key');
 
-      if (await connection.checkPairingKey()) {
+      const pairingKeyStatus = await connection.checkPairingKey();
+      if (
+        [PairingKeyStatus.NO_MATCH, PairingKeyStatus.MISSING].includes(
+          pairingKeyStatus,
+        )
+      ) {
         log.error('Desktop app not recognized');
         webSocket.close();
         throw new Error('Desktop app not recognized');

--- a/packages/app/src/shared/pairing.test.ts
+++ b/packages/app/src/shared/pairing.test.ts
@@ -5,6 +5,7 @@ import * as RawState from '@metamask/desktop/dist/utils/state';
 import TOTP from '@metamask/desktop/dist/utils/totp';
 import * as encryption from '@metamask/desktop/dist/encryption/symmetric';
 import { hashString } from '@metamask/desktop/dist/utils/crypto';
+import { PairingKeyStatus } from '@metamask/desktop/dist/types';
 import {
   createMultiplexMock,
   createStreamMock,
@@ -138,9 +139,9 @@ describe('Pairing', () => {
       });
     });
 
-    describe('isPairingKeyMatch', () => {
+    describe('checkPairingKeyMatch', () => {
       it('sends request message to desktop', async () => {
-        extensionPairing.isPairingKeyMatch();
+        extensionPairing.checkPairingKeyMatch();
         await simulateStreamMessage(keyStreamMock, {});
 
         expect(keyStreamMock.write).toHaveBeenCalledTimes(1);
@@ -149,8 +150,8 @@ describe('Pairing', () => {
         });
       });
 
-      it('returns true is desktop responds with pairing key matching extension hash', async () => {
-        const isMatchPromise = extensionPairing.isPairingKeyMatch();
+      it('returns pairingKeyMatch is desktop responds with pairing key matching extension hash', async () => {
+        const pairingKeyStatusPromise = extensionPairing.checkPairingKeyMatch();
 
         hashStringMock.mockResolvedValueOnce(HASH_BUFFER_HEX_MOCK);
 
@@ -162,17 +163,21 @@ describe('Pairing', () => {
           pairingKey: STRING_DATA_MOCK,
         });
 
-        expect(await isMatchPromise).toBe(true);
+        expect(await pairingKeyStatusPromise).toBe(
+          PairingKeyStatus.pairingKeyMatch,
+        );
       });
 
-      it('returns false is desktop responds with no pairing key', async () => {
-        const isMatchPromise = extensionPairing.isPairingKeyMatch();
+      it('returns pairingKeyNotMatch is desktop responds with no pairing key', async () => {
+        const pairingKeyStatusPromise = extensionPairing.checkPairingKeyMatch();
         await simulateStreamMessage(keyStreamMock, {});
-        expect(await isMatchPromise).toBe(false);
+        expect(await pairingKeyStatusPromise).toBe(
+          PairingKeyStatus.pairingKeyNotMatch,
+        );
       });
 
-      it('returns false is desktop responds with pairing key not matching extension hash', async () => {
-        const isMatchPromise = extensionPairing.isPairingKeyMatch();
+      it('returns pairingKeyNotMatch is desktop responds with pairing key not matching extension hash', async () => {
+        const pairingKeyStatusPromise = extensionPairing.checkPairingKeyMatch();
 
         hashStringMock.mockResolvedValueOnce(HASH_BUFFER_HEX_MOCK);
 
@@ -184,7 +189,9 @@ describe('Pairing', () => {
           pairingKey: STRING_DATA_MOCK,
         });
 
-        expect(await isMatchPromise).toBe(false);
+        expect(await pairingKeyStatusPromise).toBe(
+          PairingKeyStatus.pairingKeyNotMatch,
+        );
       });
     });
   });

--- a/packages/app/src/shared/pairing.test.ts
+++ b/packages/app/src/shared/pairing.test.ts
@@ -163,17 +163,13 @@ describe('Pairing', () => {
           pairingKey: STRING_DATA_MOCK,
         });
 
-        expect(await pairingKeyStatusPromise).toBe(
-          PairingKeyStatus.pairingKeyMatch,
-        );
+        expect(await pairingKeyStatusPromise).toBe(PairingKeyStatus.MATCH);
       });
 
       it('returns pairingKeyNotMatch is desktop responds with no pairing key', async () => {
         const pairingKeyStatusPromise = extensionPairing.checkPairingKeyMatch();
         await simulateStreamMessage(keyStreamMock, {});
-        expect(await pairingKeyStatusPromise).toBe(
-          PairingKeyStatus.pairingKeyUndefined,
-        );
+        expect(await pairingKeyStatusPromise).toBe(PairingKeyStatus.MISSING);
       });
 
       it('returns pairingKeyNotMatch is desktop responds with pairing key not matching extension hash', async () => {
@@ -189,9 +185,7 @@ describe('Pairing', () => {
           pairingKey: STRING_DATA_MOCK,
         });
 
-        expect(await pairingKeyStatusPromise).toBe(
-          PairingKeyStatus.pairingKeyNotMatch,
-        );
+        expect(await pairingKeyStatusPromise).toBe(PairingKeyStatus.NO_MATCH);
       });
     });
   });

--- a/packages/app/src/shared/pairing.test.ts
+++ b/packages/app/src/shared/pairing.test.ts
@@ -172,7 +172,7 @@ describe('Pairing', () => {
         const pairingKeyStatusPromise = extensionPairing.checkPairingKeyMatch();
         await simulateStreamMessage(keyStreamMock, {});
         expect(await pairingKeyStatusPromise).toBe(
-          PairingKeyStatus.pairingKeyNotMatch,
+          PairingKeyStatus.pairingKeyUndefined,
         );
       });
 

--- a/packages/app/src/shared/pairing.ts
+++ b/packages/app/src/shared/pairing.ts
@@ -89,7 +89,7 @@ export class ExtensionPairing {
 
     if (!desktopPairingKey) {
       log.debug('Desktop has no pairing key');
-      return PairingKeyStatus.pairingKeyUndefined;
+      return PairingKeyStatus.MISSING;
     }
 
     const desktopPairingKeyHash = await hashString(desktopPairingKey, {
@@ -104,9 +104,9 @@ export class ExtensionPairing {
     log.debug('Completed pairing key check', isMatch);
 
     if (isMatch) {
-      return PairingKeyStatus.pairingKeyMatch;
+      return PairingKeyStatus.MATCH;
     }
-    return PairingKeyStatus.pairingKeyNotMatch;
+    return PairingKeyStatus.NO_MATCH;
   }
 
   private async onRequestMessage(pairingRequest: PairingRequestMessage) {

--- a/packages/app/src/shared/pairing.ts
+++ b/packages/app/src/shared/pairing.ts
@@ -23,6 +23,7 @@ import {
   PairingKeyResponseMessage,
   PairingRequestMessage,
   PairingResultMessage,
+  PairingKeyStatus,
 } from '@metamask/desktop/dist/types';
 import * as rawState from '@metamask/desktop/dist/utils/state';
 
@@ -70,7 +71,7 @@ export class ExtensionPairing {
     return this;
   }
 
-  public async isPairingKeyMatch(): Promise<boolean> {
+  public async checkPairingKeyMatch(): Promise<PairingKeyStatus> {
     log.debug('Validating pairing key');
 
     const requestPairingKey: PairingKeyRequestMessage = {
@@ -88,7 +89,7 @@ export class ExtensionPairing {
 
     if (!desktopPairingKey) {
       log.debug('Desktop has no pairing key');
-      return false;
+      return PairingKeyStatus.pairingKeyUndefined;
     }
 
     const desktopPairingKeyHash = await hashString(desktopPairingKey, {
@@ -102,7 +103,10 @@ export class ExtensionPairing {
 
     log.debug('Completed pairing key check', isMatch);
 
-    return isMatch;
+    if (isMatch) {
+      return PairingKeyStatus.pairingKeyMatch;
+    }
+    return PairingKeyStatus.pairingKeyNotMatch;
   }
 
   private async onRequestMessage(pairingRequest: PairingRequestMessage) {

--- a/packages/app/test/mocks.ts
+++ b/packages/app/test/mocks.ts
@@ -193,7 +193,7 @@ export const createObservableStoreMock = (): jest.Mocked<ObservableStore> =>
 export const createExtensionPairingMock = (): jest.Mocked<ExtensionPairing> =>
   ({
     generateOTP: jest.fn(),
-    isPairingKeyMatch: jest.fn(),
+    checkPairingKeyMatch: jest.fn(),
     init: jest.fn(),
   } as any);
 

--- a/packages/common/src/types/desktop.ts
+++ b/packages/common/src/types/desktop.ts
@@ -32,7 +32,7 @@ export interface VersionData {
 }
 
 export enum PairingKeyStatus {
-  pairingKeyMatch,
-  pairingKeyNotMatch,
-  pairingKeyUndefined,
+  MATCH = 'MATCH',
+  NO_MATCH = 'NO_MATCH',
+  MISSING = 'MISSING',
 }

--- a/packages/common/src/types/desktop.ts
+++ b/packages/common/src/types/desktop.ts
@@ -34,5 +34,5 @@ export interface VersionData {
 export enum PairingKeyStatus {
   pairingKeyMatch,
   pairingKeyNotMatch,
-  pairingKeyUndefined
+  pairingKeyUndefined,
 }

--- a/packages/common/src/types/desktop.ts
+++ b/packages/common/src/types/desktop.ts
@@ -23,9 +23,16 @@ export interface VersionCheckResult {
 export interface TestConnectionResult {
   isConnected: boolean;
   versionCheck?: VersionCheckResult;
+  pairingKeyCheck?: PairingKeyStatus;
 }
 
 export interface VersionData {
   version: string;
   compatibilityVersion: number;
+}
+
+export enum PairingKeyStatus {
+  pairingKeyMatch,
+  pairingKeyNotMatch,
+  pairingKeyUndefined
 }


### PR DESCRIPTION
# Overview
Bug 1:  whenever disabled the pairingKeyHash was not been clean

# Changes
* Included pairingKeyHash to set status on disable
* Added `PairingKeyStatus` to facilitate error screen ticket: 135

## Issues
Resolves https://github.com/MetaMask/desktop/issues/212