### PR TITLE
Fix electron packaging on Linux

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,6 +3,7 @@
   "version": "10.22.0",
   "private": true,
   "main": "dist/app/src/app/main.js",
+  "repository": "https://github.com/MetaMask/desktop",
   "scripts": {
     "build:app": "./build/build.sh",
     "build:app:mv3": "ENABLE_MV3=true yarn build:app",


### PR DESCRIPTION
With the `publish` property in `electron-builder.json`, a `repository` field is needed in the `package.json` or an error is thrown (even when not publishing.