### PR TITLE
Compare lavamoat policies before merging

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn extension build:desktop:ui\"  \"yarn app build:app\"",
-    "build:lavamoat": "concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn extension build:desktop:ui:lavamoat\"  \"yarn app lavamoat\"",
+    "build:lavamoat": "concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn extension build:desktop:ui:lavamoat\"  \"yarn app build:app\"",
     "setup": "yarn && yarn extension setup:postinstall && yarn app setup:postinstall && yarn common build",
     "app": "yarn workspace desktop-app",
     "common": "yarn workspace @metamask/desktop",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn extension build:desktop:ui\"  \"yarn app build:app\"",
-    "build:lavamoat": "concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn extension build:desktop:ui:lavamoat\"  \"yarn app build:app\"",
+    "build:lavamoat": "concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn extension build:desktop:ui:lavamoat\"  \"yarn app lavamoat\"",
     "setup": "yarn && yarn extension setup:postinstall && yarn app setup:postinstall && yarn common build",
     "app": "yarn workspace desktop-app",
     "common": "yarn workspace @metamask/desktop",

--- a/packages/app/patches/lavamoat++lavamoat-core+12.3.0.patch
+++ b/packages/app/patches/lavamoat++lavamoat-core+12.3.0.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js b/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js
+index 05958c9..4be44b2 100644
+--- a/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js
++++ b/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js
+@@ -27,10 +27,13 @@ async function loadPolicyAndApplyOverrides({ debugMode, policyPath, policyOverri
+     if (debugMode) console.warn(`Merging policy-override.json into policy.json`)
+     const policyOverride = await readPolicyFile({ debugMode, policyPath: policyOverridePath })
+     lavamoatPolicy = mergePolicy(policy, policyOverride)
+-    // TODO: Only write if merge results in changes.
+-    // Would have to make a deep equal check on whole policy, which is a waste of time.
+-    // mergePolicy() should be able to do it in one pass.
+-    fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
++
++    if (JSON.stringify(policy) !== JSON.stringify(lavamoatPolicy)) {
++      // TODO: Only write if merge results in changes.
++      // Would have to make a deep equal check on whole policy, which is a waste of time.
++      // mergePolicy() should be able to do it in one pass.
++      fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
++    }
+   }
+   return lavamoatPolicy;
+ }

--- a/packages/app/patches/lavamoat++lavamoat-core+12.3.0.patch
+++ b/packages/app/patches/lavamoat++lavamoat-core+12.3.0.patch
@@ -1,22 +1,13 @@
 diff --git a/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js b/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js
-index 05958c9..4be44b2 100644
+index 05958c9..c5c7223 100644
 --- a/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js
 +++ b/node_modules/lavamoat/node_modules/lavamoat-core/src/loadPolicy.js
-@@ -27,10 +27,13 @@ async function loadPolicyAndApplyOverrides({ debugMode, policyPath, policyOverri
-     if (debugMode) console.warn(`Merging policy-override.json into policy.json`)
-     const policyOverride = await readPolicyFile({ debugMode, policyPath: policyOverridePath })
-     lavamoatPolicy = mergePolicy(policy, policyOverride)
--    // TODO: Only write if merge results in changes.
--    // Would have to make a deep equal check on whole policy, which is a waste of time.
--    // mergePolicy() should be able to do it in one pass.
+@@ -30,7 +30,7 @@ async function loadPolicyAndApplyOverrides({ debugMode, policyPath, policyOverri
+     // TODO: Only write if merge results in changes.
+     // Would have to make a deep equal check on whole policy, which is a waste of time.
+     // mergePolicy() should be able to do it in one pass.
 -    fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
-+
-+    if (JSON.stringify(policy) !== JSON.stringify(lavamoatPolicy)) {
-+      // TODO: Only write if merge results in changes.
-+      // Would have to make a deep equal check on whole policy, which is a waste of time.
-+      // mergePolicy() should be able to do it in one pass.
-+      fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
-+    }
++    // fs.writeFileSync(policyPath, jsonStringify(lavamoatPolicy, { space: 2 }))
    }
    return lavamoatPolicy;
  }


### PR DESCRIPTION
Compares the policies before merging them in order to avoid a packaged Linux app from failing when trying to overwrite the read-only `policy.json`