### PR TITLE
chore: add .env for desktop e2e tests

### DIFF
--- a/packages/app/.env.test.e2e
+++ b/packages/app/.env.test.e2e
@@ -1,0 +1,1 @@
+ELECTRON_APP_PATH='./dist/app/submodules/extension/app/scripts/background.js'

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -1,7 +1,11 @@
+import path from 'path';
 import { PlaywrightTestConfig } from '@playwright/test';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-require('dotenv').config();
+require('dotenv').config({
+  path: path.join(process.cwd(), '.env.test.e2e'),
+  override: true,
+});
 
 const PW_ROOT_PATH = './test/playwright';
 


### PR DESCRIPTION
# Context
We need a .env for e2e tests because whenever we want to change the electron app entry path, we need to change the ELECTRON_APP_PATH env var for the e2e tests. If that var only exists on the CI, then:
* either we update the env var and cause all other branches to fail the tests on the CI
* our branch will never pass the CI successfully

# Changes
* added a `.env.test.e2e` for e2e tests only. It will allow override any env vars previously defined. This will allow us to update any desktop e2e test variable on our branch and once that branch is merged, we can update the CI env var.