### PR TITLE
fix: resolve pairing issues in firefox

### DIFF
--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -130,7 +130,13 @@ class DesktopApp extends EventEmitter {
       ? new WebSocketStream(webSocket)
       : new EncryptedWebSocketStream(webSocket);
 
-    await webSocketStream.init({ startHandshake: false });
+    try {
+      await webSocketStream.init({ startHandshake: false });
+    } catch (error) {
+      log.error('Failed to initialise web socket stream', error);
+      webSocket.close();
+      return;
+    }
 
     const extensionConnection = new ExtensionConnection(webSocketStream);
 

--- a/packages/app/src/app/storage.test.ts
+++ b/packages/app/src/app/storage.test.ts
@@ -16,15 +16,8 @@ import ObfuscatedStore from './storage';
 jest.mock('electron-store', () => jest.fn(), { virtual: true });
 jest.mock('crypto', () => ({ randomBytes: jest.fn() }), { virtual: true });
 jest.mock('loglevel');
-
 jest.mock('path', () => ({ join: jest.fn() }), { virtual: true });
-jest.mock(
-  'fs/promises',
-  () => ({ readFile: jest.fn(), writeFile: jest.fn() }),
-  {
-    virtual: true,
-  },
-);
+jest.mock('fs/promises', () => ({ readFile: jest.fn(), writeFile: jest.fn() }));
 
 jest.mock(
   'electron',

--- a/packages/app/src/browser/node-browser.ts
+++ b/packages/app/src/browser/node-browser.ts
@@ -80,11 +80,9 @@ const proxy = (key: string[], args: any[]) => {
     requestPromises[requestId] = resolve;
   });
 
-  return timeoutPromise(
-    waitForResultMessage,
-    TIMEOUT_REQUEST,
-    `Timeout waiting for browser response - ${key.join('.')}`,
-  ).catch((error) => {
+  return timeoutPromise(waitForResultMessage, TIMEOUT_REQUEST, {
+    errorMessage: `Timeout waiting for browser response - ${key.join('.')}`,
+  }).catch((error) => {
     log.debug(error.message);
     delete requestPromises[requestId];
   });

--- a/packages/app/submodules/extension/app/scripts/background.js
+++ b/packages/app/submodules/extension/app/scripts/background.js
@@ -195,7 +195,7 @@ async function initialize(remotePort) {
   const initLangCode = await getFirstPreferredLangCode();
 
   ///: BEGIN:ONLY_INCLUDE_IN(desktopextension)
-  await DesktopManager.init(initState, platform.getVersion());
+  await DesktopManager.init(platform.getVersion());
   ///: END:ONLY_INCLUDE_IN
 
   await setupController(initState, initLangCode, remotePort);

--- a/packages/common/src/desktop-connection.test.ts
+++ b/packages/common/src/desktop-connection.test.ts
@@ -130,6 +130,7 @@ describe('Desktop Connection', () => {
     });
 
     desktopConnection = new DesktopConnection(streamMock);
+    desktopConnection.setPaired(true);
   });
 
   describe.each([

--- a/packages/common/src/desktop-connection.ts
+++ b/packages/common/src/desktop-connection.ts
@@ -53,6 +53,8 @@ export default class DesktopConnection extends EventEmitter {
 
   private disableStream: Duplex;
 
+  private browserControllerStream: Duplex;
+
   private versionCheck: VersionCheck;
 
   private extensionPairing: Pairing;
@@ -94,16 +96,16 @@ export default class DesktopConnection extends EventEmitter {
     const versionStream = this.multiplex.createStream(CLIENT_ID_VERSION);
     this.versionCheck = new VersionCheck(versionStream, this.extensionVersion);
 
-    const browserControllerStream = this.multiplex.createStream(
+    this.browserControllerStream = this.multiplex.createStream(
       CLIENT_ID_BROWSER_CONTROLLER,
     );
-    registerResponseStream(browserControllerStream);
 
     this.stream.pipe(this.multiplex).pipe(this.stream);
   }
 
-  public setPaired(isPaired: boolean) {
-    this.paired = isPaired;
+  public setPaired() {
+    this.paired = true;
+    registerResponseStream(this.browserControllerStream);
   }
 
   /**

--- a/packages/common/src/desktop-manager.test.ts
+++ b/packages/common/src/desktop-manager.test.ts
@@ -95,9 +95,9 @@ describe('Desktop Manager', () => {
   >;
 
   const initDesktopManager = async <T>(
-    promise?: Promise<T>,
+    promise: Promise<T>,
   ): Promise<T | void> => {
-    const initPromise = promise || DesktopManager.init(undefined, VERSION_MOCK);
+    const initPromise = promise || DesktopManager.init(VERSION_MOCK);
 
     await flushPromises();
     await simulateBrowserEvent(webSocketMock, 'open');
@@ -121,62 +121,6 @@ describe('Desktop Manager', () => {
     removeInstance();
 
     cfg().webSocket.disableEncryption = false;
-  });
-
-  describe('init', () => {
-    const init = async (state: any) => {
-      const promise = DesktopManager.init(state, VERSION_MOCK);
-      await initDesktopManager(promise);
-    };
-
-    describe.each([
-      ['enabled', 'encrypted', EncryptedWebSocketStream, false],
-      ['disabled', 'standard', WebSocketStream, true],
-    ])(
-      'with encryption %s',
-      (_, streamType, webSocketStreamConstructor, disableEncryption) => {
-        beforeEach(async () => {
-          cfg().webSocket.disableEncryption = disableEncryption;
-
-          await init({
-            DesktopController: {
-              desktopEnabled: true,
-              pairingKey: 'mockedKey',
-            },
-          });
-        });
-
-        it(`creates and inits ${streamType} web socket stream`, async () => {
-          expect(webSocketStreamConstructor).toHaveBeenCalledTimes(1);
-          expect(webSocketStreamConstructor).toHaveBeenCalledWith(
-            webSocketMock,
-          );
-
-          expect(webSocketStreamMock.init).toHaveBeenCalledTimes(1);
-        });
-
-        it('creates desktop connection', async () => {
-          expect(desktopConnectionConstructorMock).toHaveBeenCalledTimes(1);
-          expect(desktopConnectionConstructorMock).toHaveBeenCalledWith(
-            webSocketStreamMock,
-            VERSION_MOCK,
-          );
-        });
-
-        it('transfers state', async () => {
-          expect(desktopConnectionMock.transferState).toHaveBeenCalledTimes(1);
-        });
-      },
-    );
-
-    it('does nothing if state has desktop disabled', async () => {
-      await init({ DesktopController: { desktopEnabled: false } });
-
-      expect(WebSocketStream).toHaveBeenCalledTimes(0);
-      expect(EncryptedWebSocketStream).toHaveBeenCalledTimes(0);
-      expect(webSocketStreamMock.init).toHaveBeenCalledTimes(0);
-      expect(desktopConnectionConstructorMock).toHaveBeenCalledTimes(0);
-    });
   });
 
   describe('getConnection', () => {
@@ -251,7 +195,7 @@ describe('Desktop Manager', () => {
 
   describe('testConnection', () => {
     beforeEach(async () => {
-      await DesktopManager.init(undefined, VERSION_MOCK);
+      await DesktopManager.init(VERSION_MOCK);
     });
 
     const testConnection = async (): Promise<TestConnectionResult> => {

--- a/packages/common/src/desktop-manager.ts
+++ b/packages/common/src/desktop-manager.ts
@@ -196,7 +196,9 @@ class DesktopManager {
       return;
     }
 
-    await connection.transferState();
+    if (!cfg().isExtensionTest) {
+      await connection.transferState();
+    }
 
     this.transferredState = true;
   }

--- a/packages/common/src/pairing.ts
+++ b/packages/common/src/pairing.ts
@@ -3,8 +3,11 @@ import { Duplex } from 'stream';
 // @ts-ignore
 import ObjectMultiplex from 'obj-multiplex';
 import log from './utils/log';
-import { MESSAGE_ACKNOWLEDGE } from './constants';
-import { waitForAcknowledge, waitForMessage } from './utils/stream';
+import {
+  addDataListener,
+  waitForAcknowledge,
+  waitForMessage,
+} from './utils/stream';
 import TOTP from './utils/totp';
 import { createKey } from './encryption/symmetric';
 import { hashString } from './utils/crypto';
@@ -40,12 +43,8 @@ export class Pairing {
   }
 
   public init() {
-    this.requestStream.on('data', (data: PairingRequestMessage | string) => {
-      if (data === MESSAGE_ACKNOWLEDGE) {
-        return;
-      }
-
-      this.onRequestMessage(data as PairingRequestMessage);
+    addDataListener(this.requestStream, (data: any) => {
+      this.onRequestMessage(data);
     });
 
     return this;

--- a/packages/common/src/utils/stream.ts
+++ b/packages/common/src/utils/stream.ts
@@ -30,6 +30,19 @@ export const acknowledge = (stream: Writable) => {
   stream.write(MESSAGE_ACKNOWLEDGE);
 };
 
+export const addDataListener = (
+  stream: Readable,
+  listener: (data: any) => void,
+) => {
+  stream.on('data', (data: any) => {
+    if (data === MESSAGE_ACKNOWLEDGE) {
+      return;
+    }
+
+    listener(data);
+  });
+};
+
 export class DuplexCopy extends Duplex {
   private stream: Duplex;
 

--- a/packages/common/src/utils/utils.ts
+++ b/packages/common/src/utils/utils.ts
@@ -26,7 +26,10 @@ export const flattenMessage = (data: any) => {
 export const timeoutPromise = <T>(
   promise: Promise<T>,
   timeout: number,
-  errorMessage?: string,
+  options: {
+    errorMessage?: string;
+    cleanUp?: () => void;
+  } = {},
 ): Promise<T> => {
   return new Promise<T>((resolve, reject) => {
     let complete = false;
@@ -34,7 +37,11 @@ export const timeoutPromise = <T>(
     const timeoutInstance = setTimeout(() => {
       complete = true;
 
-      reject(new Error(errorMessage || `Promise timeout after ${timeout}ms`));
+      options.cleanUp?.();
+
+      reject(
+        new Error(options.errorMessage || `Promise timeout after ${timeout}ms`),
+      );
     }, timeout);
 
     promise

--- a/packages/common/test/mocks.ts
+++ b/packages/common/test/mocks.ts
@@ -139,6 +139,7 @@ export const createDesktopConnectionMock = (): jest.Mocked<DesktopConnection> =>
     createStream: jest.fn(),
     removeAllListeners: jest.fn(),
     checkPairingKey: jest.fn(),
+    setPaired: jest.fn(),
   } as any);
 
 export const createObservableStoreMock = (): jest.Mocked<ObservableStore> =>


### PR DESCRIPTION
# Overview

Resolve issues preventing successful pairing in Firefox.

# Changes

## App

- Add error handling after failed web socket stream initialisation.

## Common

- Ignore acknowledgement messages in desktop connection state stream.
- Ignore all state and disable messages until desktop connection is paired.
- Remove connection during initialisation and always lazily connect when needed.
- Add timeout to encryption handshake.
- Add automatic resend to both sides of encryption handshake.
- Add timeout and error handling to web socket stream writes.
- Add error handling after failed web socket stream initialisation.