### PR TITLE
fix: add descriptive message to otp pair screen of ext

### DIFF
--- a/packages/app/submodules/extension/app/_locales/en/messages.json
+++ b/packages/app/submodules/extension/app/_locales/en/messages.json
@@ -1019,6 +1019,9 @@
   "desktopOutdatedExtensionErrorTitle": {
     "message": "MetaMask Extension is outdated"
   },
+  "desktopPageDescription": {
+    "message": "If the pairing is successful, extension will restart and you'll have to re-enter your password."
+  },
   "desktopPageSubTitle": {
     "message": "Open your MetaMask Desktop and type this code"
   },

--- a/packages/app/submodules/extension/ui/pages/desktop-pairing/desktop-pairing.component.js
+++ b/packages/app/submodules/extension/ui/pages/desktop-pairing/desktop-pairing.component.js
@@ -128,6 +128,9 @@ export default function DesktopPairingPage({
           </span>{' '}
           seconds
         </Typography>
+        <div className="desktop-pairing__description">
+          {t('desktopPageDescription')}
+        </div>
       </div>
     );
   };

--- a/packages/app/submodules/extension/ui/pages/desktop-pairing/index.scss
+++ b/packages/app/submodules/extension/ui/pages/desktop-pairing/index.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-flow: column;
   align-items: center;
-  padding: 0 30px 30px;
+  padding: 0 30px 0;
 
   &__countdown-timer {
     background: #f2f3f4;
@@ -30,7 +30,8 @@
     padding-top: 24px;
   }
 
-  &__subtitle {
+  &__subtitle,
+  &__description {
     font-style: normal;
     font-weight: 400;
     font-size: 14px;
@@ -39,6 +40,10 @@
     color: #000;
     padding-top: 8px;
     margin: 0 56px;
+  }
+
+  &__description {
+    margin: 24px 0;
   }
 
   &__otp {
@@ -54,6 +59,5 @@
     width: 70%;
     justify-content: space-between;
     margin: auto;
-    padding-top: 48px;
   }
 }


### PR DESCRIPTION
## Overview
This PR aims to add small paragraph to extension pairing screen.

## Screenshot 
![Screenshot 2022-12-08 at 09 13 00](https://user-images.githubusercontent.com/7644512/206394718-2dba9247-04e2-4a90-8c69-25d24de2d5b1.png)
