### PR TITLE
feat: add setting icon in pairing page

### DIFF
--- a/packages/app/ui/components/icons/settings-icon.js
+++ b/packages/app/ui/components/icons/settings-icon.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function SettingIcon({
+  width = '17',
+  height = '21',
+  fill = 'white',
+}) {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 512 512"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m417 199c-37 0-52-26-33-58 10-19 4-43-15-53l-35-21c-16-9-37-4-47 13l-2 4c-19 32-49 32-67 0l-3-4c-9-17-30-22-46-13l-35 21c-19 10-25 34-15 53 19 32 4 58-33 58-22 0-39 17-39 39l0 36c0 21 17 39 39 39 37 0 52 26 33 58-10 19-4 43 15 53l35 21c16 9 37 4 47-13l2-4c18-32 49-32 67 0l3 4c9 17 30 22 46 13l36-21c18-10 25-34 14-53-19-32-3-58 34-58 21 0 39-17 39-39l0-36c-1-21-18-39-40-39z m-165 124c-37 0-67-30-67-67 0-37 30-67 67-67 36 0 66 30 66 67 0 37-30 67-66 67z"
+        fill={fill}
+      />
+    </svg>
+  );
+}
+
+SettingIcon.propTypes = {
+  /**
+   * Width of the icon
+   */
+  width: PropTypes.string,
+  /**
+   * Height of the icon
+   */
+  height: PropTypes.string,
+  /**
+   * Fill  of the icon should be a valid design system color
+   */
+  fill: PropTypes.string,
+};

--- a/packages/app/ui/components/pair-status/index.scss
+++ b/packages/app/ui/components/pair-status/index.scss
@@ -24,4 +24,8 @@
     font-size: 12px;
     margin: 16px 0 10px;
   }
+
+  &__pair-now {
+    width: 300px;
+  }
 }

--- a/packages/app/ui/components/pair-status/pair-status.component.js
+++ b/packages/app/ui/components/pair-status/pair-status.component.js
@@ -1,18 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 
 import useI18nContext from '../../hooks/useI18nContext';
 import Chip from '../../../submodules/extension/ui/components/ui/chip';
 import Typography from '../../../submodules/extension/ui/components/ui/typography';
+import Button from '../../../submodules/extension/ui/components/ui/button';
 import {
   COLORS,
   TYPOGRAPHY,
   FONT_WEIGHT,
 } from '../../../submodules/extension/ui/helpers/constants/design-system';
 import { formatDate } from '../../../submodules/extension/ui/helpers/utils/util';
+import { PAIR_ROUTE } from '../../helpers/constants/routes';
 
-const PairStatus = ({ isWebSocketConnected, lastActivation }) => {
+const PairStatus = ({
+  isWebSocketConnected,
+  lastActivation,
+  isPairingEverCompleted,
+}) => {
   const t = useI18nContext();
+  const history = useHistory();
 
   const renderChip = () => {
     const color = isWebSocketConnected
@@ -40,9 +48,29 @@ const PairStatus = ({ isWebSocketConnected, lastActivation }) => {
     );
   };
 
+  const renderPairNowButton = () => {
+    return (
+      <div className="mmd-pair-status__pair-now">
+        <Button
+          className="mmd-pair-status__pair-now-button"
+          type="secondary"
+          onClick={() => {
+            history.push(PAIR_ROUTE);
+          }}
+        >
+          {t('pairNow')}
+        </Button>
+      </div>
+    );
+  };
+
   const renderlastActivation = () => {
     return formatDate(lastActivation);
   };
+
+  if (!isPairingEverCompleted) {
+    return renderPairNowButton();
+  }
 
   return (
     <div className="mmd-pair-status">
@@ -67,6 +95,10 @@ PairStatus.propTypes = {
    * The last time the desktop app was activated
    */
   lastActivation: PropTypes.number,
+  /**
+   * Whether the desktop app has ever been paired with the extension
+   */
+  isPairingEverCompleted: PropTypes.bool,
 };
 
 export default PairStatus;

--- a/packages/app/ui/css/index.scss
+++ b/packages/app/ui/css/index.scss
@@ -14,6 +14,7 @@ body {
 #mmd-app-content {
   padding: 0 16px;
   height: 100%;
+  position: relative;
 }
 
 #mmd-draggable-hidden-bar {

--- a/packages/app/ui/ducks/pair-status/pair-status.js
+++ b/packages/app/ui/ducks/pair-status/pair-status.js
@@ -51,9 +51,8 @@ export const getIsWebSocketConnected = (state) =>
 export const getIsSuccessfulPairSeen = (state) =>
   state.pairStatus.isSuccessfulPairSeen;
 export const getIsPairingEverCompleted = (state) => {
-  const { isDesktopEnabled, isWebSocketConnected, isSuccessfulPairSeen } =
-    state.pairStatus;
-  return isDesktopEnabled || isWebSocketConnected || isSuccessfulPairSeen;
+  const { isDesktopEnabled, isSuccessfulPairSeen } = state.pairStatus;
+  return isDesktopEnabled || isSuccessfulPairSeen;
 };
 
 // Action Creators

--- a/packages/app/ui/ducks/pair-status/pair-status.js
+++ b/packages/app/ui/ducks/pair-status/pair-status.js
@@ -50,6 +50,11 @@ export const getIsWebSocketConnected = (state) =>
   state.pairStatus.isWebSocketConnected;
 export const getIsSuccessfulPairSeen = (state) =>
   state.pairStatus.isSuccessfulPairSeen;
+export const getIsPairingEverCompleted = (state) => {
+  const { isDesktopEnabled, isWebSocketConnected, isSuccessfulPairSeen } =
+    state.pairStatus;
+  return isDesktopEnabled || isWebSocketConnected || isSuccessfulPairSeen;
+};
 
 // Action Creators
 export function updatePairStatus(payload) {

--- a/packages/app/ui/locales/en.js
+++ b/packages/app/ui/locales/en.js
@@ -155,6 +155,12 @@ const enLocales = {
   desktopErrorNavigateSettingsCTA: {
     message: 'Return to Settings Page',
   },
+  otpTimeoutError: {
+    message: 'Timeout in OTP check, please try again',
+  },
+  pairNow: {
+    message: 'Pair with your MetaMask extension',
+  },
 };
 
 export default enLocales;

--- a/packages/app/ui/pages/pair/index.scss
+++ b/packages/app/ui/pages/pair/index.scss
@@ -7,6 +7,14 @@ $otp-height: 142px;
   align-items: center;
   justify-content: center;
 
+  &__settings-icon {
+    position: absolute;
+    top: 0;
+    right: 16px;
+    color: var(--color-text-muted);
+    cursor: pointer;
+  }
+
   &__spinner {
     width: 50px;
     margin: 80px 0;

--- a/packages/app/ui/pages/pair/pair.component.js
+++ b/packages/app/ui/pages/pair/pair.component.js
@@ -22,7 +22,6 @@ import Spinner from '../../../submodules/extension/ui/components/ui/spinner';
 const ANIMATION_COMPLETE_DEFER_IN_MS = 1000;
 const OTP_VALIDATION_TIMEOUT_IN_MS = 5000;
 
-
 const Pair = ({ isDesktopEnabled, isSuccessfulPairSeen, history }) => {
   const t = useI18nContext();
   const [otp, setOtp] = React.useState('');
@@ -68,7 +67,7 @@ const Pair = ({ isDesktopEnabled, isSuccessfulPairSeen, history }) => {
       setTimeout(() => {
         window.electronBridge.sendOtp(otpValue);
       }, ANIMATION_COMPLETE_DEFER_IN_MS);
-      
+
       // Show timeout error after 5 seconds of no response when validating
       const timeoutId = setTimeout(() => {
         setOtpTimeoutError(true);

--- a/packages/app/ui/pages/pair/pair.component.js
+++ b/packages/app/ui/pages/pair/pair.component.js
@@ -9,6 +9,7 @@ import {
 } from '../../helpers/constants/routes';
 import useI18nContext from '../../hooks/useI18nContext';
 import Typography from '../../../submodules/extension/ui/components/ui/typography';
+import SettingIcon from '../../components/icons/settings-icon';
 import {
   FONT_WEIGHT,
   TYPOGRAPHY,
@@ -18,18 +19,25 @@ import {
 import Mascot from '../../../submodules/extension/ui/components/ui/mascot';
 import Spinner from '../../../submodules/extension/ui/components/ui/spinner';
 
+const ANIMATION_COMPLETE_DEFER_IN_MS = 1000;
+const OTP_VALIDATION_TIMEOUT_IN_MS = 5000;
+
+
 const Pair = ({ isDesktopEnabled, isSuccessfulPairSeen, history }) => {
   const t = useI18nContext();
   const [otp, setOtp] = React.useState('');
   const [isOtpValidating, setOtpValidating] = React.useState(false);
-  const [otpError, setOtpError] = React.useState(false);
+  const [isInvalidOtpError, setInvalidOtpError] = React.useState(false);
+  const [isOtpTimeoutError, setOtpTimeoutError] = React.useState(false);
+  const [otpValidationTimeoutId, setOtpValidationTimeoutId] =
+    React.useState(null);
   const [isOtpDisabled, setOtpDisabled] = React.useState(false);
   const animationEventEmitter = new EventEmitter();
 
   useEffect(() => {
     window.electronBridge.onInvalidOtp(() => {
       setOtpDisabled(false);
-      setOtpError(true);
+      setInvalidOtpError(true);
       setOtpValidating(false);
     });
 
@@ -41,70 +49,104 @@ const Pair = ({ isDesktopEnabled, isSuccessfulPairSeen, history }) => {
   useEffect(() => {
     if (isDesktopEnabled) {
       console.log('Paired, redirecting');
+      clearTimeout(otpValidationTimeoutId);
       if (isSuccessfulPairSeen) {
         history.push(SETTINGS_ROUTE);
       } else {
         history.push(SUCCESSFUL_PAIR_ROUTE);
       }
     }
-  }, [isDesktopEnabled, isSuccessfulPairSeen, history]);
+  }, [isDesktopEnabled, isSuccessfulPairSeen, history, otpValidationTimeoutId]);
 
   const handleOTPChange = (otpValue) => {
     setOtp(otpValue);
     if (otpValue.length === 6) {
       setOtpDisabled(true);
       setOtpValidating(true);
+
+      // This timeout for the animation to complete
       setTimeout(() => {
         window.electronBridge.sendOtp(otpValue);
-      }, 1000);
+      }, ANIMATION_COMPLETE_DEFER_IN_MS);
+      
+      // Show timeout error after 5 seconds of no response when validating
+      const timeoutId = setTimeout(() => {
+        setOtpTimeoutError(true);
+        setOtpValidating(false);
+        setOtpDisabled(false);
+      }, OTP_VALIDATION_TIMEOUT_IN_MS + ANIMATION_COMPLETE_DEFER_IN_MS);
+      setOtpValidationTimeoutId(timeoutId);
     }
   };
 
+  const handleOnSettinsIconClick = () => {
+    history.push(SETTINGS_ROUTE);
+  };
+
   return (
-    <div className="mmd-pair-page">
-      <Mascot
-        animationEventEmitter={animationEventEmitter}
-        width="150"
-        height="150"
-      />
-      <Typography variant={TYPOGRAPHY.H3} fontWeight={FONT_WEIGHT.BOLD}>
-        {t('syncWithExtension')}
-      </Typography>
-      <Typography variant={TYPOGRAPHY.Paragraph} fontSize={14}>
-        {t('typeTheSixDigitCodeBelow')}
-      </Typography>
-      {isOtpValidating ? (
-        <Spinner
-          className="mmd-pair-page__spinner"
-          color="var(--color-secondary-default)"
+    <>
+      <div
+        className="mmd-pair-page__settings-icon"
+        onClick={handleOnSettinsIconClick}
+      >
+        <SettingIcon width="24" height="24" fill="var(--color-text-muted)" />
+      </div>
+      <div className="mmd-pair-page">
+        <Mascot
+          animationEventEmitter={animationEventEmitter}
+          width="150"
+          height="150"
         />
-      ) : (
-        <div className="mmd-pair-page__otp-input__container">
-          <OtpInput
-            isInputNum
-            isDisabled={isOtpDisabled}
-            hasErrored={otpError}
-            value={otp}
-            onChange={handleOTPChange}
-            numInputs={6}
-            inputStyle="mmd-pair-page__otp-input"
-            disabledStyle="mmd-pair-page__otp-input__disabled"
-            errorStyle="mmd-pair-page__otp-input__error"
+        <Typography variant={TYPOGRAPHY.H3} fontWeight={FONT_WEIGHT.BOLD}>
+          {t('syncWithExtension')}
+        </Typography>
+        <Typography variant={TYPOGRAPHY.Paragraph} fontSize={14}>
+          {t('typeTheSixDigitCodeBelow')}
+        </Typography>
+        {isOtpValidating ? (
+          <Spinner
+            className="mmd-pair-page__spinner"
+            color="var(--color-secondary-default)"
           />
-          {otpError && (
-            <Typography
-              variant={TYPOGRAPHY.Paragraph}
-              fontSize={14}
-              color={COLORS.ERROR_DEFAULT}
-              align={TEXT_ALIGN.CENTER}
-              className="mmd-pair-page__otp-input__error-message"
-            >
-              {t('invalidOtpCode')}
-            </Typography>
-          )}
-        </div>
-      )}
-    </div>
+        ) : (
+          <div className="mmd-pair-page__otp-input__container">
+            <OtpInput
+              isInputNum
+              isDisabled={isOtpDisabled}
+              hasErrored={isInvalidOtpError || isOtpTimeoutError}
+              value={otp}
+              onChange={handleOTPChange}
+              numInputs={6}
+              inputStyle="mmd-pair-page__otp-input"
+              disabledStyle="mmd-pair-page__otp-input__disabled"
+              errorStyle="mmd-pair-page__otp-input__error"
+            />
+            {isInvalidOtpError && (
+              <Typography
+                variant={TYPOGRAPHY.Paragraph}
+                fontSize={14}
+                color={COLORS.ERROR_DEFAULT}
+                align={TEXT_ALIGN.CENTER}
+                className="mmd-pair-page__otp-input__error-message"
+              >
+                {t('invalidOtpCode')}
+              </Typography>
+            )}
+            {isOtpTimeoutError && (
+              <Typography
+                variant={TYPOGRAPHY.Paragraph}
+                fontSize={14}
+                color={COLORS.ERROR_DEFAULT}
+                align={TEXT_ALIGN.CENTER}
+                className="mmd-pair-page__otp-input__error-message"
+              >
+                {t('otpTimeoutError')}
+              </Typography>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/packages/app/ui/pages/settings/general-tab/general-tab.component.js
+++ b/packages/app/ui/pages/settings/general-tab/general-tab.component.js
@@ -17,6 +17,7 @@ const GeneralTab = ({
   updateCurrentLanguage,
   theme,
   updateTheme,
+  isPairingEverCompleted,
 }) => {
   const t = useI18nContext();
 
@@ -122,10 +123,12 @@ const GeneralTab = ({
       <PairStatus
         isWebSocketConnected={isWebSocketConnected}
         lastActivation={lastActivation}
+        isPairingEverCompleted={isPairingEverCompleted}
       />
       {renderLanguageSettings()}
       {renderThemeSettings()}
-      {isWebSocketConnected ? renderUnpairButton() : renderResetButton()}
+      {isPairingEverCompleted &&
+        (isWebSocketConnected ? renderUnpairButton() : renderResetButton())}
     </>
   );
 };
@@ -155,6 +158,10 @@ GeneralTab.propTypes = {
    * Updates the current theme
    */
   updateTheme: PropTypes.func,
+  /**
+   * Whether the desktop app has ever been paired with the extension
+   */
+  isPairingEverCompleted: PropTypes.bool,
 };
 
 export default GeneralTab;

--- a/packages/app/ui/pages/settings/general-tab/general-tab.container.js
+++ b/packages/app/ui/pages/settings/general-tab/general-tab.container.js
@@ -11,11 +11,13 @@ import {
 import {
   getLastActivation,
   getIsWebSocketConnected,
+  getIsPairingEverCompleted,
 } from '../../../ducks/pair-status/pair-status';
 import GeneralTab from './general-tab.component';
 
 function mapStateToProps(state) {
   return {
+    isPairingEverCompleted: getIsPairingEverCompleted(state),
     isWebSocketConnected: getIsWebSocketConnected(state),
     lastActivation: getLastActivation(state),
     language: getLanguage(state),

--- a/packages/app/ui/pages/settings/settings.component.js
+++ b/packages/app/ui/pages/settings/settings.component.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Switch, Route, matchPath, useHistory } from 'react-router-dom';
 
@@ -6,7 +6,6 @@ import {
   GENERAL_ROUTE,
   ABOUT_US_ROUTE,
   SETTINGS_ROUTE,
-  PAIR_ROUTE,
 } from '../../helpers/constants/routes';
 import TabBar from '../../../submodules/extension/ui/components/app/tab-bar';
 import Typography from '../../../submodules/extension/ui/components/ui/typography';
@@ -15,16 +14,9 @@ import useI18nContext from '../../hooks/useI18nContext';
 import GeneralTab from './general-tab';
 import AboutTab from './about-tab';
 
-const Settings = ({ currentPath, isAboutPage, isDesktopEnabled }) => {
+const Settings = ({ currentPath, isAboutPage }) => {
   const t = useI18nContext();
   const history = useHistory();
-
-  useEffect(() => {
-    if (!isDesktopEnabled) {
-      console.log('Unpaired, redirecting');
-      history.push(PAIR_ROUTE);
-    }
-  }, [isDesktopEnabled, history]);
 
   const renderTabs = () => {
     return (
@@ -108,10 +100,6 @@ Settings.propTypes = {
    * Whether the current page is the about page
    */
   isAboutPage: PropTypes.bool,
-  /**
-   * Whether the extension is paired with the desktop app
-   */
-  isDesktopEnabled: PropTypes.bool,
 };
 
 export default Settings;

--- a/packages/app/ui/pages/settings/settings.container.js
+++ b/packages/app/ui/pages/settings/settings.container.js
@@ -2,18 +2,16 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
-import { getIsDesktopEnabled } from '../../ducks/pair-status/pair-status';
 import { ABOUT_US_ROUTE } from '../../helpers/constants/routes';
 import Settings from './settings.component';
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(_, ownProps) {
   const {
     location: { pathname },
   } = ownProps;
   return {
     currentPath: pathname,
     isAboutPage: pathname === ABOUT_US_ROUTE,
-    isDesktopEnabled: getIsDesktopEnabled(state),
   };
 }
 


### PR DESCRIPTION
## Overview
This PR aims to 
* add settings icon to pair page, so user can navigate between settings and pair page even if not paired
* add timeout error after 5s of validating OTP 

![Screenshot 2022-12-12 at 09 48 05](https://user-images.githubusercontent.com/7644512/207001784-868a3f22-05cb-452c-aad2-97f82b57b89f.png)

![Screenshot 2022-12-12 at 09 48 22](https://user-images.githubusercontent.com/7644512/207001890-9e1b2eee-2d18-446a-bddf-c37fe63eac92.png)

