### PR TITLE
Prevent publishing packages in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,7 +544,7 @@ jobs:
             mv ./${APP_DIR}/dist-ui ./${APP_DIR}/dist/ui
       - run:
           name: Package Windows nsis installer
-          command: yarn app package:win:ci
+          command: yarn app package:win:ci -p "never"
       - run:
           name: Move executable to its own folder
           command: |
@@ -570,7 +570,7 @@ jobs:
             mv ./${APP_DIR}/dist-ui ./${APP_DIR}/dist/ui
       - run:
           name: Package Linux AppImage
-          command: yarn app package:linux:ci
+          command: yarn app package:linux:ci -p "never"
       - run:
           name: Move executable to its own folder
           command: |

--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -55,7 +55,7 @@ jobs:
               if [ "$RUNNER_OS" == "Linux" ]; then
                 yarn app package:linux:ci -p "never"
               elif [ "$RUNNER_OS" == "Windows" ]; then
-                yarn app package:win:ci
+                yarn app package:win:ci -p "never"
               else
                 echo "$RUNNER_OS not supported"
                 exit 1


### PR DESCRIPTION
## Overview
Stops CI from trying to publish electron-builder packages.

Even though in the Pull Request CI this one an issue, merges in the `main-desktop` branch are attempting to publish packages, which is not a feature we have ready yet and that we don't want for CircleCI.

Example of `main-desktop` pipeline breaking:
https://app.circleci.com/pipelines/github/MetaMask/desktop/1126/workflows/1769ea6c-5f1e-4228-a20f-b656a223b1d8