### PR TITLE
feat: add ui store migrations

### DIFF
--- a/packages/app/.iyarc
+++ b/packages/app/.iyarc
@@ -2,6 +2,7 @@
 GHSA-257v-vj4p-3w2h
 GHSA-hrpp-h998-j3pp
 GHSA-v5vg-g7rq-363w
+GHSA-h452-7996-h45h
 
 # pending review
 GHSA-6xrf-q977-5vgc

--- a/packages/app/ui/ducks/index.js
+++ b/packages/app/ui/ducks/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
-import { persistReducer } from 'redux-persist';
+import { persistReducer, createMigrate } from 'redux-persist';
 
+import pairStatusMigrations from '../migrations/pair-status';
+import rootMigrations from '../migrations/root';
 import appReducer from './app/app';
 import pairStatusReducer from './pair-status/pair-status';
 
@@ -9,6 +11,8 @@ const pairStatusPersistConfig = {
   storage: window.electronBridge.pairStatusStore,
   blacklist: ['connections', 'isWebSocketConnected', 'isDesktopPaired'],
   whitelist: ['isSuccessfulPairSeen', 'lastActivation'],
+  migrate: createMigrate(pairStatusMigrations, { debug: false }),
+  version: 0,
 };
 const persistedPairStatusReducer = persistReducer(
   pairStatusPersistConfig,
@@ -18,6 +22,8 @@ const persistedPairStatusReducer = persistReducer(
 const appPersistConfig = {
   key: 'app',
   storage: window.electronBridge.appStore,
+  migrate: createMigrate(rootMigrations, { debug: false }),
+  version: 0,
 };
 const persistedAppReducer = persistReducer(appPersistConfig, appReducer);
 

--- a/packages/app/ui/migrations/pair-status/index.js
+++ b/packages/app/ui/migrations/pair-status/index.js
@@ -1,0 +1,8 @@
+// import m1 from './m1';
+
+const migrations = {
+  // version: migration function
+  // 1: m1,
+};
+
+export default migrations;

--- a/packages/app/ui/migrations/pair-status/m1.js
+++ b/packages/app/ui/migrations/pair-status/m1.js
@@ -1,0 +1,14 @@
+/*
+
+Migration description
+
+*/
+
+function migration(state) {
+  console.log('Running first pair status migration');
+  return {
+    ...state,
+  };
+}
+
+export default migration;

--- a/packages/app/ui/migrations/root/index.js
+++ b/packages/app/ui/migrations/root/index.js
@@ -1,0 +1,8 @@
+// import m1 from './m1';
+
+const migrations = {
+  // version: migration function
+  // 1: m1,
+};
+
+export default migrations;

--- a/packages/app/ui/migrations/root/m1.js
+++ b/packages/app/ui/migrations/root/m1.js
@@ -1,0 +1,14 @@
+/*
+
+Migration description
+
+*/
+
+function migration(state) {
+  console.log('Running first root migration');
+  return {
+    ...state,
+  };
+}
+
+export default migration;


### PR DESCRIPTION
## Overview
This PR aims to add an implementation of UI store migration base.
Since we persist two different stores (`pair-status` and `root`) we need individual migration functions for each. 
All persisted store versions will start from 0 and it will increment once migration happens. 

### Example migration implementation
-  Increment migration version (For example, make `rootPersistedConfig` version 0 to 1)
- Add a migration file under `packages/app/ui/migrations/root/m1.js`
- Add file reference to `index.js` with version and migration function
```
const migrations = {
  // version: migration function
  1: m1,
  2: m2,
  3: m3,
  //...
};
```
- Fill migration function

### How to reproduce migration in local
- Start app with migration version 0 for the store you want to migrate
- Kill app
- Increment version number by 1
- Set `createMigrate` function option `debug` to true (`packages/app/ui/ducks/index.js`)
- Start app (it will also run migrations)
- You can use UI developer tools to debug since that migration happens on UI
