### PR TITLE
Add more excludes to tsconfig

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -17,10 +17,12 @@
   "exclude": [
     "**/*.test.js",
     "**/*.test.ts",
-    "dist/**/*",
-    "node_modules/**",
-    "packages/**",
-    "test/playwright/**"
+    "dist",
+    "node_modules",
+    "packages",
+    "submodules/**/dist",
+    "submodules/**/node_modules",
+    "test/playwright"
   ],
   "extends": "@tsconfig/node16/tsconfig.json",
   "paths": {


### PR DESCRIPTION
I've been getting this warning every time I open vscode, so I was wondering if it was due to some folders (`node_modules`, `dist`, etc) from the submodule directory not being excluded.

I have rewritten the excludes and the warning now does no longer appear when opening vscode, so I think that was the reason.

![image](https://user-images.githubusercontent.com/1970725/207624028-f53ada16-34ee-423d-8b82-6ad1c4dd2e74.png)

Also, when giving a folder, it does not look like it's necessary to specify that we want to include all the files inside with `**`, but if we want to leave it like that for convention it's ok.