### PR TITLE
chore: support runtime env to test compatibility version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
           at: .
       - run:
           name: build
-          command: yarn app build:app:test
+          command: yarn app build:app:test:extension
       - run:
           name: Move dist to avoid conflicts
           command: mv ./${APP_DIR}/dist/app ./${APP_DIR}/dist-app-test-extension
@@ -316,7 +316,7 @@ jobs:
           at: .
       - run:
           name: build
-          command: yarn app build:app:test:ui
+          command: yarn app build:app:test:app
       - run:
           name: Move dist to avoid conflicts
           command: mv ./${APP_DIR}/dist/app ./${APP_DIR}/dist-app-test-app

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app\"",
     "build:lavamoat": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn app build:ui:lavamoat\"  \"yarn app build:app\"",
-    "build:test:extension": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:test:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app:test\"",
+    "build:test:app": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:test:desktop:app\" \"yarn app build:ui\"  \"yarn app build:app:test:app\"",
+    "build:test:extension": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:test:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app:test:extension\"",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts npm yarn github.com codeload.github.com --empty-hostname false --allowed-schemes \"https:\" \"git+https:\"",
     "setup": "yarn setup:submodule && yarn && yarn setup:postinstall && yarn common setup:postinstall && yarn app setup:postinstall && yarn common build && yarn setup:extension && yarn extension setup",
     "setup:extension": "sh scripts/init-extension.sh",

--- a/packages/app/babel-app.config.js
+++ b/packages/app/babel-app.config.js
@@ -17,7 +17,10 @@ module.exports = function (api) {
       ? []
       : [
           ['./build/code-fencing-babel', { buildType: 'desktopapp' }],
-          'transform-inline-environment-variables',
+          [
+            'transform-inline-environment-variables',
+            { exclude: ['COMPATIBILITY_VERSION_DESKTOP_TEST'] },
+          ],
         ],
     ignore: [
       '**/*.config.js',

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,8 +6,8 @@
   "repository": "https://github.com/MetaMask/desktop",
   "scripts": {
     "build:app": "./build/build.sh",
-    "build:app:test": "IN_TEST=true SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' PHISHING_WARNING_PAGE_URL=http://localhost:9999/ METAMASK_DEBUG=1 yarn build:app",
-    "build:app:test:ui": "UI_TEST=true METAMASK_DEBUG=1 yarn build:app",
+    "build:app:test:extension": "IN_TEST=true SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' PHISHING_WARNING_PAGE_URL=http://localhost:9999/ METAMASK_DEBUG=1 yarn build:app",
+    "build:app:test:app": "UI_TEST=true METAMASK_DEBUG=1 yarn build:app",
     "build:ui": "node build/ui/desktop-ui.js dev --apply-lavamoat=false",
     "build:ui:ci": "node build/ui/desktop-ui.js dist --apply-lavamoat=false",
     "build:ui:subtask": "node build/ui/desktop-ui.js",

--- a/packages/app/src/utils/config.ts
+++ b/packages/app/src/utils/config.ts
@@ -7,15 +7,29 @@ import {
 const loadConfig = () => {
   // Cannot use dynamic references to envs as build system does find and replace
   const port = envInt(process.env.WEB_SOCKET_PORT, 7071);
+  const isAppTest = envBool(process.env.UI_TEST);
+
+  const compatibilityVersionDesktopTest = envInt(
+    process.env.COMPATIBILITY_VERSION_DESKTOP_TEST,
+  );
+
+  const compatibilityVersionDesktop = envInt(
+    process.env.COMPATIBILITY_VERSION_DESKTOP,
+  );
+
+  const compatibilityVersionDesktopFinal =
+    isAppTest && compatibilityVersionDesktopTest !== undefined
+      ? compatibilityVersionDesktopTest
+      : compatibilityVersionDesktop;
 
   return {
     enableUpdates: envBool(process.env.DESKTOP_ENABLE_UPDATES),
     isExtensionTest: envBool(process.env.IN_TEST),
-    isAppTest: envBool(process.env.UI_TEST),
+    isAppTest,
     isUnitTest: envStringMatch(process.env.NODE_ENV, 'test'),
     skipOtpPairingFlow: envBool(process.env.SKIP_OTP_PAIRING_FLOW),
     compatibilityVersion: {
-      desktop: envInt(process.env.COMPATIBILITY_VERSION_DESKTOP, 1),
+      desktop: compatibilityVersionDesktopFinal,
     },
     webSocket: {
       disableEncryption: envBool(process.env.DISABLE_WEB_SOCKET_ENCRYPTION),

--- a/packages/app/src/utils/config.ts
+++ b/packages/app/src/utils/config.ts
@@ -15,6 +15,7 @@ const loadConfig = () => {
 
   const compatibilityVersionDesktop = envInt(
     process.env.COMPATIBILITY_VERSION_DESKTOP,
+    1,
   );
 
   const compatibilityVersionDesktopFinal =

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -11,6 +11,9 @@ module.exports = {
     {
       files: ['**/*.ts'],
       extends: ['@metamask/eslint-config-typescript'],
+      rules: {
+        'jsdoc/require-jsdoc': 'off',
+      },
     },
     {
       files: ['**/*.test.ts', '**/*.test.js'],

--- a/packages/common/src/utils/config.ts
+++ b/packages/common/src/utils/config.ts
@@ -11,15 +11,17 @@ export const envStringMatch = (
     : false;
 };
 
-export const envInt = (
+export function envInt(value: string | undefined): number | undefined;
+export function envInt(value: string | undefined, defaultValue: number): number;
+export function envInt(
   value: string | undefined,
-  defaultValue: number,
-): number => {
+  defaultValue?: number,
+): number | undefined {
   if (!value) {
     return defaultValue;
   }
   return parseInt(value, 10);
-};
+}
 
 export const envBool = (
   value: string | boolean | undefined,


### PR DESCRIPTION
# Overview

Support the `COMPATIBILITY_VERSION_DESKTOP_TEST` environment variable at runtime to override the compatibility version in the app for testing.

# Changes

## Root

- Create `build:test:app` package script to simplify building all components when running the E2E app tests.

## App

- If `UI_TEST` env is `true`, set the compatibility version using the `COMPATIBILITY_VERSION_DESKTOP_TEST` env if set, or fallback to the `COMPATIBILITY_VERSION_DESKTOP` env.
- Exclude new env from transform at build time to support runtime usage.
- Rename the test build package scripts to be consistent with the test scripts.

## Common

- Make default value optional when reading envs as integers.