### PR TITLE
chore/patch release package to ignore root level tags

### DIFF
--- a/.github/workflows/publish-common-release.yml
+++ b/.github/workflows/publish-common-release.yml
@@ -75,8 +75,8 @@ jobs:
         run: |
           PACKAGE_JSON="./packages/common/package.json"
           RELEASE_VERSION="$(jq --raw-output .version $PACKAGE_JSON)"
-          echo "commmon@$RELEASE_VERSION"
-          gh release create "commmon@$RELEASE_VERSION" -F packages/common/CHANGELOG.md
+          echo "@metamask/desktop@$RELEASE_VERSION"
+          gh release create "@metamask/desktop@$RELEASE_VERSION" -F packages/common/CHANGELOG.md
 
   # Optionally perform a dry-run publish to review
   publish-common-npm-dry-run:

--- a/patches/@metamask+create-release-branch+1.0.1.patch
+++ b/patches/@metamask+create-release-branch+1.0.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@metamask/create-release-branch/dist/command-line-arguments.js b/node_modules/@metamask/create-release-branch/dist/command-line-arguments.js
-index b3df9ed..d1cdabf 100644
+index b3df9ed..a457eb6 100644
 --- a/node_modules/@metamask/create-release-branch/dist/command-line-arguments.js
 +++ b/node_modules/@metamask/create-release-branch/dist/command-line-arguments.js
 @@ -34,6 +34,11 @@ async function readCommandLineArguments(argv) {
@@ -15,10 +15,10 @@ index b3df9ed..d1cdabf 100644
          .help()
          .strict()
 diff --git a/node_modules/@metamask/create-release-branch/dist/initial-parameters.js b/node_modules/@metamask/create-release-branch/dist/initial-parameters.js
-index 65562cd..dccda9e 100644
+index 65562cd..e61a44d 100644
 --- a/node_modules/@metamask/create-release-branch/dist/initial-parameters.js
 +++ b/node_modules/@metamask/create-release-branch/dist/initial-parameters.js
-@@ -21,15 +21,18 @@ const project_1 = require("./project");
+@@ -21,10 +21,12 @@ const project_1 = require("./project");
  async function determineInitialParameters({ argv, cwd, stderr, }) {
      const args = await (0, command_line_arguments_1.readCommandLineArguments)(argv);
      const projectDirectoryPath = path_1.default.resolve(cwd, args.projectDirectory);
@@ -32,14 +32,8 @@ index 65562cd..dccda9e 100644
      return {
          project,
          tempDirectoryPath,
-         reset: args.reset,
-         releaseType: args.backport ? 'backport' : 'ordinary',
-+        workspacePackage
-     };
- }
- exports.determineInitialParameters = determineInitialParameters;
 diff --git a/node_modules/@metamask/create-release-branch/dist/package-manifest.js b/node_modules/@metamask/create-release-branch/dist/package-manifest.js
-index d7060dc..603fb41 100644
+index d7060dc..c54f0c9 100644
 --- a/node_modules/@metamask/create-release-branch/dist/package-manifest.js
 +++ b/node_modules/@metamask/create-release-branch/dist/package-manifest.js
 @@ -132,8 +132,13 @@ function isValidPackageManifestWorkspacesField(workspaces) {
@@ -57,11 +51,76 @@ index d7060dc..603fb41 100644
      if (!schema.validate(value)) {
          throw new Error(buildPackageManifestFieldValidationErrorMessage({
              manifest,
+diff --git a/node_modules/@metamask/create-release-branch/dist/package.js b/node_modules/@metamask/create-release-branch/dist/package.js
+index c862a5b..7b030e7 100644
+--- a/node_modules/@metamask/create-release-branch/dist/package.js
++++ b/node_modules/@metamask/create-release-branch/dist/package.js
+@@ -45,14 +45,15 @@ function generateMonorepoWorkspacePackageReleaseTagName(packageName, packageVers
+  * @param args.projectTagNames - The tag names across the whole project.
+  * @returns Information about the package.
+  */
+-async function readMonorepoRootPackage({ packageDirectoryPath, projectDirectoryPath, projectTagNames, }) {
++async function readMonorepoRootPackage({ packageDirectoryPath, projectDirectoryPath, projectTagNames, byPassRootTag }) {
+     const manifestPath = path_1.default.join(packageDirectoryPath, MANIFEST_FILE_NAME);
+     const changelogPath = path_1.default.join(packageDirectoryPath, CHANGELOG_FILE_NAME);
+     const { unvalidated: unvalidatedManifest, validated: validatedManifest } = await (0, package_manifest_1.readPackageManifest)(manifestPath);
+     const expectedTagNameForLatestRelease = generateMonorepoRootPackageReleaseTagName(validatedManifest.version.toString());
+     const matchingTagNameForLatestRelease = projectTagNames.find((tagName) => tagName === expectedTagNameForLatestRelease);
+     if (projectTagNames.length > 0 &&
+-        matchingTagNameForLatestRelease === undefined) {
++        matchingTagNameForLatestRelease === undefined &&
++        !byPassRootTag) {
+         throw new Error((0, util_1.format)('The package %s has no Git tag for its current version %s (expected %s), so this tool is unable to determine whether it should be included in this release. You will need to create a tag for this package in order to proceed.', validatedManifest.name, validatedManifest.version, `"${expectedTagNameForLatestRelease}"`));
+     }
+     const hasChangesSinceLatestRelease = matchingTagNameForLatestRelease === undefined
+@@ -82,7 +83,10 @@ exports.readMonorepoRootPackage = readMonorepoRootPackage;
+  * @param args.stderr - A stream that can be used to write to standard error.
+  * @returns Information about the package.
+  */
+-async function readMonorepoWorkspacePackage({ packageDirectoryPath, rootPackageName, rootPackageVersion, projectDirectoryPath, projectTagNames, stderr, }) {
++async function readMonorepoWorkspacePackage({ packageDirectoryPath, rootPackageName, rootPackageVersion, projectDirectoryPath, projectTagNames, stderr, byPassRootTag }) {
++    if (byPassRootTag) {
++      return await readMonorepoWorkspacePackageNoRootTag({ packageDirectoryPath, projectDirectoryPath, projectTagNames });
++    }
+     const manifestPath = path_1.default.join(packageDirectoryPath, MANIFEST_FILE_NAME);
+     const changelogPath = path_1.default.join(packageDirectoryPath, CHANGELOG_FILE_NAME);
+     const { unvalidated: unvalidatedManifest, validated: validatedManifest } = await (0, package_manifest_1.readPackageManifest)(manifestPath);
+@@ -111,6 +115,30 @@ async function readMonorepoWorkspacePackage({ packageDirectoryPath, rootPackageN
+         hasChangesSinceLatestRelease,
+     };
+ }
++
++async function readMonorepoWorkspacePackageNoRootTag({ packageDirectoryPath, projectDirectoryPath, projectTagNames }) {
++  const manifestPath = path_1.default.join(packageDirectoryPath, MANIFEST_FILE_NAME);
++  const changelogPath = path_1.default.join(packageDirectoryPath, CHANGELOG_FILE_NAME);
++  const { unvalidated: unvalidatedManifest, validated: validatedManifest } = await (0, package_manifest_1.readPackageManifest)(manifestPath);
++  const expectedTagNameForWorkspacePackageLatestRelease = generateMonorepoWorkspacePackageReleaseTagName(validatedManifest.name, validatedManifest.version.toString());
++  const matchingTagNameForWorkspacePackageLatestRelease = projectTagNames.find((tagName) => tagName === expectedTagNameForWorkspacePackageLatestRelease);
++
++  if (projectTagNames.length > 0 &&
++    !matchingTagNameForWorkspacePackageLatestRelease) {
++      throw new Error((0, util_1.format)('The current release of workspace package %s, %s, has no corresponding Git tag %s. Hence, this tool is unable to know whether the workspace package changed and should be included in this release. You will need to create tags for both of these packages in order to proceed.', validatedManifest.name, validatedManifest.version, `"${expectedTagNameForWorkspacePackageLatestRelease}"`));
++  }
++
++  const hasChangesSinceLatestRelease = await (0, repo_1.hasChangesInDirectorySinceGitTag)(projectDirectoryPath, packageDirectoryPath, matchingTagNameForWorkspacePackageLatestRelease);
++  return {
++      directoryPath: packageDirectoryPath,
++      manifestPath,
++      validatedManifest,
++      unvalidatedManifest,
++      changelogPath,
++      hasChangesSinceLatestRelease,
++  };
++}
++
+ exports.readMonorepoWorkspacePackage = readMonorepoWorkspacePackage;
+ /**
+  * Updates the changelog file of the given package using
 diff --git a/node_modules/@metamask/create-release-branch/dist/project.js b/node_modules/@metamask/create-release-branch/dist/project.js
-index 6a114e6..7e6c679 100644
+index 6a114e6..260cc9f 100644
 --- a/node_modules/@metamask/create-release-branch/dist/project.js
 +++ b/node_modules/@metamask/create-release-branch/dist/project.js
-@@ -40,7 +40,7 @@ function examineReleaseVersion(packageVersion) {
+@@ -40,21 +40,26 @@ function examineReleaseVersion(packageVersion) {
   * monorepo) or if any of the workspaces specified in the root `package.json` do
   * not have `package.json`s (monorepo only).
   */
@@ -70,8 +129,10 @@ index 6a114e6..7e6c679 100644
      const repositoryUrl = await (0, repo_1.getRepositoryHttpsUrl)(projectDirectoryPath);
      const tagNames = await (0, repo_1.getTagNames)(projectDirectoryPath);
      const rootPackage = await (0, package_1.readMonorepoRootPackage)({
-@@ -49,12 +49,16 @@ async function readProject(projectDirectoryPath, { stderr }) {
+         packageDirectoryPath: projectDirectoryPath,
+         projectDirectoryPath,
          projectTagNames: tagNames,
++        byPassRootTag: workspacePackage ? true : false
      });
      const releaseVersion = examineReleaseVersion(rootPackage.validatedManifest.version);
 -    const workspaceDirectories = (await Promise.all(rootPackage.validatedManifest[package_manifest_1.PackageManifestFieldNames.Workspaces].map(async (workspacePattern) => {
@@ -88,3 +149,11 @@ index 6a114e6..7e6c679 100644
      const workspacePackages = (await Promise.all(workspaceDirectories.map(async (directory) => {
          return await (0, package_1.readMonorepoWorkspacePackage)({
              packageDirectoryPath: directory,
+@@ -63,6 +68,7 @@ async function readProject(projectDirectoryPath, { stderr }) {
+             projectDirectoryPath,
+             projectTagNames: tagNames,
+             stderr,
++            byPassRootTag: workspacePackage ? true : false
+         });
+     }))).reduce((obj, pkg) => {
+         return Object.assign(Object.assign({}, obj), { [pkg.validatedManifest.name]: pkg });


### PR DESCRIPTION
# Context
Patch the create-release-branch to ignore root level tags (i.e. `v<version>`) in order to compute existing changes. If we are creating a release for a specific workspace, then we should only check that workspace tags.

# Changes
* patch the create-release-branch
* update the publish common github action to reference the actual tag `@metamask/desktop@<version>`