### PR TITLE
chore: remove private from package.json

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@metamask/desktop",
   "version": "0.0.1",
-  "private": true,
   "main": "dist/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Context
Remove `private` property from common package.json. This will allow publishing it as `@metamask/desktop` to npm.

(https://docs.npmjs.com/cli/v9/configuring-npm/package-json#private)
