### PR TITLE
fix: incoming connection management

### DIFF
--- a/.iyarc
+++ b/.iyarc
@@ -2,3 +2,7 @@
 GHSA-257v-vj4p-3w2h
 GHSA-hrpp-h998-j3pp
 GHSA-v5vg-g7rq-363w
+# ticket created to fix the vulnerabilities below
+GHSA-8gh8-hqwg-xf34
+GHSA-6xrf-q977-5vgc
+GHSA-9c47-m6qq-7p4h

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -48,7 +48,7 @@ if (!cfg().isUnitTest) {
 class DesktopApp extends EventEmitter {
   private extensionConnection?: ExtensionConnection;
 
-  private onHoldExtensionConnection?: ExtensionConnection;
+  private additionalExtensionConnection?: ExtensionConnection;
 
   private status: StatusMessage;
 
@@ -225,7 +225,13 @@ class DesktopApp extends EventEmitter {
     // if a connection is active it should set new connection as on hold
     // so the user unpair properly before establishing a new connection
     if (this.extensionConnection && this.status.isDesktopEnabled) {
-      this.onHoldExtensionConnection = extensionConnection;
+      if (this.additionalExtensionConnection) {
+        this.additionalExtensionConnection.disconnect();
+        this.additionalExtensionConnection.removeAllListeners();
+        this.additionalExtensionConnection = undefined;
+      }
+
+      this.additionalExtensionConnection = extensionConnection;
       return;
     }
     this.extensionConnection = extensionConnection;
@@ -253,8 +259,8 @@ class DesktopApp extends EventEmitter {
     if (connection === this.extensionConnection) {
       this.extensionConnection = undefined;
       this.status.isWebSocketConnected = false;
-    } else if (connection === this.onHoldExtensionConnection) {
-      this.onHoldExtensionConnection = undefined;
+    } else if (connection === this.additionalExtensionConnection) {
+      this.additionalExtensionConnection = undefined;
     }
 
     this.status.connections = [];

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -224,7 +224,7 @@ class DesktopApp extends EventEmitter {
 
     // if a connection is active it should set new connection as on hold
     // so the user unpair properly before establishing a new connection
-    if (this.extensionConnection) {
+    if (this.extensionConnection && this.status.isDesktopEnabled) {
       this.onHoldExtensionConnection = extensionConnection;
       return;
     }
@@ -253,6 +253,8 @@ class DesktopApp extends EventEmitter {
     if (connection === this.extensionConnection) {
       this.extensionConnection = undefined;
       this.status.isWebSocketConnected = false;
+    } else if (connection === this.onHoldExtensionConnection) {
+      this.onHoldExtensionConnection = undefined;
     }
 
     this.status.connections = [];

--- a/packages/app/src/desktop-ui.js
+++ b/packages/app/src/desktop-ui.js
@@ -10,6 +10,9 @@ start().catch((error) => {
   console.log('Error starting desktop app', error);
 });
 
+/**
+ * Starts the desktop app
+ */
 function start() {
   return launchDesktopUi();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,7 +2948,7 @@
     glob "^7.1.7"
     semver "^7.3.5"
 
-"@metamask/auto-changelog@^2.1.0", "@metamask/auto-changelog@^2.6.1":
+"@metamask/auto-changelog@^2.1.0":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.6.1.tgz#5a6291df6c1592f010bd54f1a97814a4570b1eaf"
   integrity sha512-7VI4lftbQQHbZcxl1W+qFTWHxoeDGybL22Q70SNyYUVIBLlK5PirJHPh1zVYL4jEFmW0rItLLAXd/OZDuVG1Jg==


### PR DESCRIPTION
## Overview
Whenever [createConnection](https://github.com/MetaMask/desktop/blob/main-desktop/packages/common/src/desktop-manager.ts#L93)   is called on `testConnection` (user clicked Desktop Enable button) it checks the pairing key. If it does not match the WebSocket connection is closed, and an error screen is shown to the user indicating that MMD is already paired with another extension and in order to proceed it's necessary to reset that on the desktop app.

## Changes
### Desktop app
- `desktop-app.ts`: introduced `onHoldExtensionConnection` in case the paired extension is open and active while extension 2 tries to create a WebSocket connection and checks for the pairing key.
  - `this.status.isWebSocketConnected` moved to be set to false only when the `this.extensionConnection` is set to undefined.

### Common
The logic on common is already prepared to throw an error and close the WebSocket connection in case of the pairing key is different.

### Extension
Basically, on the extension, the warning notification was converted to a full error screen.
[PR related](https://github.com/MetaMask/desktop-extension/pull/5)

Resolves: https://github.com/MetaMask/desktop/issues/357