### PR TITLE
fix: pair status component

### DIFF
--- a/packages/app/src/desktop-ui.js
+++ b/packages/app/src/desktop-ui.js
@@ -10,6 +10,9 @@ start().catch((error) => {
   console.log('Error starting desktop app', error);
 });
 
+/**
+ * Starts the desktop app
+ */
 function start() {
   return launchDesktopUi();
 }

--- a/packages/app/ui/ducks/index.js
+++ b/packages/app/ui/ducks/index.js
@@ -8,8 +8,8 @@ import pairStatusReducer from './pair-status/pair-status';
 const pairStatusPersistConfig = {
   key: 'pairStatus',
   storage: window.electronBridge.pairStatusStore,
-  blacklist: ['connections', 'isWebSocketConnected'],
-  whitelist: ['isDesktopEnabled', 'isSuccessfulPairSeen', 'lastActivation'],
+  blacklist: ['connections', 'isWebSocketConnected', 'isDesktopEnabled'],
+  whitelist: ['isSuccessfulPairSeen', 'lastActivation'],
 };
 const persistedPairStatusReducer = persistReducer(
   pairStatusPersistConfig,

--- a/packages/app/ui/ducks/pair-status/pair-status.js
+++ b/packages/app/ui/ducks/pair-status/pair-status.js
@@ -50,10 +50,6 @@ export const getIsWebSocketConnected = (state) =>
   state.pairStatus.isWebSocketConnected;
 export const getIsSuccessfulPairSeen = (state) =>
   state.pairStatus.isSuccessfulPairSeen;
-export const getIsPairingEverCompleted = (state) => {
-  const { isDesktopEnabled, isSuccessfulPairSeen } = state.pairStatus;
-  return isDesktopEnabled || isSuccessfulPairSeen;
-};
 
 // Action Creators
 export function updatePairStatus(payload) {

--- a/packages/app/ui/locales/en.js
+++ b/packages/app/ui/locales/en.js
@@ -161,6 +161,9 @@ const enLocales = {
   pairNow: {
     message: 'Pair with your MetaMask extension',
   },
+  pairInProgress: {
+    message: 'Pair in progress, show pairing page',
+  },
 };
 
 export default enLocales;

--- a/packages/app/ui/pages/settings/general-tab/general-tab.component.js
+++ b/packages/app/ui/pages/settings/general-tab/general-tab.component.js
@@ -12,12 +12,13 @@ import useI18nContext from '../../../hooks/useI18nContext';
 
 const GeneralTab = ({
   isWebSocketConnected,
+  isDesktopEnabled,
+  isSuccessfulPairSeen,
   lastActivation,
   language,
   updateCurrentLanguage,
   theme,
   updateTheme,
-  isPairingEverCompleted,
 }) => {
   const t = useI18nContext();
 
@@ -123,11 +124,12 @@ const GeneralTab = ({
       <PairStatus
         isWebSocketConnected={isWebSocketConnected}
         lastActivation={lastActivation}
-        isPairingEverCompleted={isPairingEverCompleted}
+        isDesktopEnabled={isDesktopEnabled}
+        isSuccessfulPairSeen={isSuccessfulPairSeen}
       />
       {renderLanguageSettings()}
       {renderThemeSettings()}
-      {isPairingEverCompleted &&
+      {isSuccessfulPairSeen &&
         (isWebSocketConnected ? renderUnpairButton() : renderResetButton())}
     </>
   );
@@ -159,9 +161,13 @@ GeneralTab.propTypes = {
    */
   updateTheme: PropTypes.func,
   /**
-   * Whether the desktop app has ever been paired with the extension
+   * Whether the desktop app is enabled
    */
-  isPairingEverCompleted: PropTypes.bool,
+  isDesktopEnabled: PropTypes.bool,
+  /**
+   * Whether the user has successfully paired with the desktop app
+   */
+  isSuccessfulPairSeen: PropTypes.bool,
 };
 
 export default GeneralTab;

--- a/packages/app/ui/pages/settings/general-tab/general-tab.container.js
+++ b/packages/app/ui/pages/settings/general-tab/general-tab.container.js
@@ -11,13 +11,15 @@ import {
 import {
   getLastActivation,
   getIsWebSocketConnected,
-  getIsPairingEverCompleted,
+  getIsDesktopEnabled,
+  getIsSuccessfulPairSeen,
 } from '../../../ducks/pair-status/pair-status';
 import GeneralTab from './general-tab.component';
 
 function mapStateToProps(state) {
   return {
-    isPairingEverCompleted: getIsPairingEverCompleted(state),
+    isDesktopEnabled: getIsDesktopEnabled(state),
+    isSuccessfulPairSeen: getIsSuccessfulPairSeen(state),
     isWebSocketConnected: getIsWebSocketConnected(state),
     lastActivation: getLastActivation(state),
     language: getLanguage(state),


### PR DESCRIPTION
## Overview
This PR aims to improve the readability of the `pair-status` component.
We were caching `isDesktopEnabled` just to understand if the user was already paired with the extension. But we already have `isSuccessfulPairSeen` in place for the same reason hence `isDesktopEnabled` is removed from the cache whitelist.