### PR TITLE
fix: add write permissions to create gh release

### DIFF
--- a/.github/workflows/publish-common-release.yml
+++ b/.github/workflows/publish-common-release.yml
@@ -63,6 +63,8 @@ jobs:
   publish-common-release:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
# Context
gh needs to have permissions to create both tag and release on the desktop repo.
