### PR TITLE
Release 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "build": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app\"",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0]
+## [0.1.1]
 ### Uncategorized
 - chore: remove private from package.json ([#348](https://github.com/MetaMask/desktop/pull/348))
 - chore: support runtime env to test compatibility version ([#340](https://github.com/MetaMask/desktop/pull/340))
@@ -25,5 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move encryption and generic utils to common workspace ([#264](https://github.com/MetaMask/desktop/pull/264))
 - Move browser and version check logic to common workspace ([#259](https://github.com/MetaMask/desktop/pull/259))
 
-[Unreleased]: https://github.com/MetaMask/desktop/compare/@metamask/desktop@0.1.0...HEAD
-[0.1.0]: https://github.com/MetaMask/desktop/releases/tag/@metamask/desktop@0.1.0
+[Unreleased]: https://github.com/MetaMask/desktop/compare/@metamask/desktop@0.1.1...HEAD
+[0.1.1]: https://github.com/MetaMask/desktop/releases/tag/@metamask/desktop@0.1.1

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Context
Release of `@metamask/desktop@0.1.1`.
We are bypassing v0.1.0 as that was not published to npm