### PR TITLE
fix: host file null and disable host when ci true

### DIFF
--- a/scripts/init-submodule.sh
+++ b/scripts/init-submodule.sh
@@ -3,6 +3,13 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+# Point the host file to null and disable host checking
+if [ "$CI" = "true" ];
+then
+    echo "CI: setting GIT_SSH_COMMAND"
+    export GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+fi
+
 # Initialise and clone submodules
 git submodule init
 git submodule update


### PR DESCRIPTION
## Overview
Whenever CI is true disables hist and sets hist file to null in `init-submodule.sh`.

It solves [the pipeline issue](https://app.circleci.com/pipelines/github/MetaMask/desktop-extension/46/workflows/7d217953-5e6f-4bc0-87d3-33534dc1b202/jobs/1118) in desktop-extension.
