### PR TITLE
fix: add publish script to common workspace

### DIFF
--- a/.github/workflows/publish-common-release.yml
+++ b/.github/workflows/publish-common-release.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Publish
         id: publish
         shell: bash
-        run: yarn common npm publish
+        run: yarn common publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,8 @@
     "lint:tsc": "tsc --project tsconfig.json --noEmit",
     "setup:postinstall": "yarn allow-scripts",
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "publish": "yarn npm publish"
   },
   "dependencies": {
     "@metamask/obs-store": "^5.0.0",


### PR DESCRIPTION
# Changes
Add publish script to common workspace.
We need that because If we try yarn common npm publish, we will get an error stating that npm command is not found. This is because it will try to actually run npm instead of the yarn npm command.
