### PR TITLE
Automate desktop app release process

### DIFF
--- a/.github/workflows/package-app-dev.yml
+++ b/.github/workflows/package-app-dev.yml
@@ -1,0 +1,29 @@
+name: "Package Desktop App - Dev"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check-app-dev-workflows:
+    name: Lints workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: download-actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.download-actionlint.outputs.executable }} -color .github/workflows/publish-common-release.yml
+        shell: bash
+
+  package-dev:
+    environment: development
+    uses: ./.github/workflows/package-app.yml
+    secrets:
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+      MMD_WIN_CERT_BASE64: ${{ secrets.MMD_WIN_CERT_BASE64_DEV }}
+      MMD_WIN_CERT_PASSWORD: ${{ secrets.MMD_WIN_CERT_PASSWORD_DEV }}
+      MMD_MAC_CSC_BASE64: ${{ secrets.MMD_MAC_CSC_BASE64_DEV }}
+      MMD_MAC_CSC_KEY_PASSWORD: ${{ secrets.MMD_MAC_CSC_KEY_PASSWORD_DEV }}
+      PUBLISH: "false"

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -3,6 +3,12 @@ name: "Package and Publish Desktop App"
 
 on:
   workflow_dispatch:
+    inputs:
+      bypass_is_release:
+        type: boolean
+        required: false
+        description: Bypass is release job
+        default: false
   push:
     paths:
       - packages/app/**
@@ -31,6 +37,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     steps:
       - id: is-release
+        if:  ${{ !github.event.inputs.bypass_is_release }}
         uses: MetaMask/action-is-release@v1
         with:
           commit-starts-with: 'Release App [version]'
@@ -38,7 +45,7 @@ jobs:
   publish-app-release-draft:
     runs-on: ubuntu-latest
     needs: is-release
-    if: needs.is-release.outputs.IS_RELEASE == 'true'
+    if: ${{ needs.is-release.outputs.IS_RELEASE == 'true' || github.event.inputs.bypass_is_release }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -1,0 +1,69 @@
+# .github/workflows/publish-app.yml
+name: "Package and Publish Desktop App"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - packages/app/**
+    branches: [app-stable]
+
+concurrency: production
+
+jobs:
+  check-app-workflows:
+    name: Lints workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: download-actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.download-actionlint.outputs.executable }} -color .github/workflows/publish-common-release.yml
+        shell: bash
+
+  is-release:
+    name: Determine whether this is a release merge commit
+    runs-on: ubuntu-latest
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    steps:
+      - id: is-release
+        uses: MetaMask/action-is-release@v1
+        with:
+          commit-starts-with: 'Release App [version]'
+
+  publish-app-release-draft:
+    runs-on: ubuntu-latest
+    needs: is-release
+    if: needs.is-release.outputs.IS_RELEASE == 'true'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      - name: Create Tag and Github Release
+        id: tag-and-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          PACKAGE_JSON="./packages/app/package.json"
+          RELEASE_VERSION="$(jq --raw-output .version $PACKAGE_JSON)"
+          echo "v@$RELEASE_VERSION"
+          gh release create "v@$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d
+
+  package-prod:
+    needs: publish-app-release-draft
+    environment: production
+    uses: ./.github/workflows/package-app.yml
+    secrets:
+      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
+      MMD_WIN_CERT_BASE64: ${{ secrets.MMD_WIN_CERT_BASE64 }}
+      MMD_WIN_CERT_PASSWORD: ${{ secrets.MMD_WIN_CERT_PASSWORD }}
+      MMD_MAC_CSC_BASE64: ${{ secrets.MMD_MAC_CSC_BASE64 }}
+      MMD_MAC_CSC_KEY_PASSWORD: ${{ secrets.MMD_MAC_CSC_KEY_PASSWORD }}
+      PUBLISH: "true"

--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -67,15 +67,19 @@ jobs:
         shell: bash
         run:  |
               PUBLISH_PACKAGE="never"
+              # Mac package script to avoid notarization as it can only be done with the prod certificate.
+              MAC_PACKAGE_SCRIPT="package:mac"
               if [ "${{ secrets.PUBLISH }}" == "true" ]; then
                 PUBLISH_PACKAGE = "always"
+                # Mac package script to include notarization.
+                MAC_PACKAGE_SCRIPT="package:mac:ci"
               fi
               if [ "$RUNNER_OS" == "Linux" ]; then
-                yarn app package:linux:ci -p "${{ secrets.PUBLISH_PACKAGE }}"
+                yarn app package:linux:ci -p "$PUBLISH_PACKAGE"
               elif [ "$RUNNER_OS" == "Windows" ]; then
-                yarn app package:win:ci -p "${{ secrets.PUBLISH_PACKAGE }}"
+                yarn app package:win:ci -p "$PUBLISH_PACKAGE"
               elif [ "$RUNNER_OS" == "macOS" ]; then
-                yarn app package:mac:ci -p "${{ secrets.PUBLISH_PACKAGE }}"
+                yarn app "$MAC_PACKAGE_SCRIPT" -p "$PUBLISH_PACKAGE"
               else
                 echo "$RUNNER_OS not supported"
                 exit 1

--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -1,6 +1,20 @@
 name: "Build and Package"
 
-on: workflow_dispatch
+on:
+  workflow_call:
+    secrets:
+      MMD_WIN_CERT_BASE64:
+        required: true
+      MMD_WIN_CERT_PASSWORD:
+        required: true
+      MMD_MAC_CSC_BASE64:
+        required: true
+      MMD_MAC_CSC_KEY_PASSWORD:
+        required: true
+      INFURA_PROJECT_ID:
+        required: true
+      PUBLISH:
+        required: true
 
 jobs:
   package:
@@ -8,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout Git Repository
@@ -52,10 +66,16 @@ jobs:
       - name: Package app for ${{ matrix.os }}
         shell: bash
         run:  |
+              PUBLISH_PACKAGE="never"
+              if [ "${{ secrets.PUBLISH }}" == "true" ]; then
+                PUBLISH_PACKAGE = "always"
+              fi
               if [ "$RUNNER_OS" == "Linux" ]; then
-                yarn app package:linux:ci -p "never"
+                yarn app package:linux:ci -p "${{ secrets.PUBLISH_PACKAGE }}"
               elif [ "$RUNNER_OS" == "Windows" ]; then
-                yarn app package:win:ci -p "never"
+                yarn app package:win:ci -p "${{ secrets.PUBLISH_PACKAGE }}"
+              elif [ "$RUNNER_OS" == "macOS" ]; then
+                yarn app package:mac:ci -p "${{ secrets.PUBLISH_PACKAGE }}"
               else
                 echo "$RUNNER_OS not supported"
                 exit 1
@@ -63,3 +83,5 @@ jobs:
         env:
           WIN_CSC_LINK: ${{ secrets.MMD_WIN_CERT_BASE64 }}
           WIN_CSC_KEY_PASSWORD: ${{ secrets.MMD_WIN_CERT_PASSWORD }}
+          CSC_LINK: ${{ secrets.MMD_MAC_CSC_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MMD_MAC_CSC_KEY_PASSWORD }}

--- a/.github/workflows/package-app.yml
+++ b/.github/workflows/package-app.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
@@ -89,3 +92,4 @@ jobs:
           WIN_CSC_KEY_PASSWORD: ${{ secrets.MMD_WIN_CERT_PASSWORD }}
           CSC_LINK: ${{ secrets.MMD_MAC_CSC_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.MMD_MAC_CSC_KEY_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-common-release.yml
+++ b/.github/workflows/publish-common-release.yml
@@ -15,7 +15,7 @@ on:
     branches: [main-desktop]
 
 jobs:
-  check-workflows:
+  check-common-workflows:
     name: Lints workflow
     runs-on: ubuntu-latest
     steps:
@@ -132,6 +132,3 @@ jobs:
         run: yarn common publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-
-

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "desktop",
   "version": "2.0.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/desktop.git"
+  },
   "scripts": {
     "build": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app\"",
     "build:lavamoat": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn app build:ui:lavamoat\"  \"yarn app build:app\"",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/desktop/

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-app",
-  "version": "10.22.0",
+  "version": "0.0.1",
   "private": true,
   "main": "dist/app/src/app/main.js",
   "repository": "https://github.com/MetaMask/desktop",


### PR DESCRIPTION
# Changes
Adds github actions that will automate the release process for the desktop app. Also initialized the changelog file for the app workspace.

### Added actions:
**Generic action to package the desktop app:**
This action will run on all supported OS (windows, linux and mac) and as so it requires both windows and mac certificates to be there.
It also requires a `Publish` variable that will indicate if electron-builder will publish the app (to github) after packaging it. And  in the MacOS scenario, it will also run the notarization process.
 
**Package app in dev mode:**
Uses the generic package app. Sets the required variables to the dev value (using the Github [development environment](https://github.com/MetaMask/desktop/settings/environments/776376532/edit)). It will not publish the packaged apps and will not run the notarization process. Can be manually dispatched.

**Package and publish in prod mode (using prod certificates):**
Uses the generic package app. Sets the required variables to the Prod value (using the Github [production environment](https://github.com/MetaMask/desktop/settings/environments/776376532/edit)). It will create a draft release and tag on Github (using the Changelog file as input for the release) and will publish the packaged apps (for MacOS it will run the notarization process). Is automatically dispatched whenever theres a release commit on the `app-stable` branch (this is target to be the branch that keeps track of our stable app releases) that has changes on the `packages/app` dir path. (For now it can also be dispatched manually, so that we can test it properly.. as Github actions are quite difficult to test locally, especially for multiple OS)