### PR TITLE
Add metamask/desktop package readme and files for package

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,3 @@
+# @metamask/desktop
+
+Set of utils and functionalities required for both the MetaMask Desktop App and MetaMask Extension to be able to work together.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/MetaMask/desktop.git"
   },
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build": "rimraf dist && tsc --build",
     "lint": "yarn lint:prettier && yarn lint:eslint && yarn lint:tsc",


### PR DESCRIPTION
# Changes
Add readme to common workspace and only include `dist` files when packaging the common workspace.