### PR TITLE
Fix: windows packaged timeout while performing handshake

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -35,7 +35,7 @@
     "package:mac:ci": "electron-builder --config electron-builder.ci.json -m",
     "package:win": "dotenv -e .metamaskrc -- electron-builder -w",
     "package:win:ci": "electron-builder --config electron-builder.ci.json -w",
-    "package:win:docker": "docker compose -f build/windows/docker-compose.yml up",
+    "package:win:docker": "docker-compose -f build/windows/docker-compose.yml up",
     "release:linux": "electron-builder -l -p 'onTagOrDraft'",
     "setup:postinstall": "yarn patch-package && yarn allow-scripts",
     "start": "electron dist/app/src/app/main.js",

--- a/packages/common/src/encryption/web-socket-stream.ts
+++ b/packages/common/src/encryption/web-socket-stream.ts
@@ -15,7 +15,7 @@ import * as asymmetricEncryption from './asymmetric';
 import * as symmetricEncryption from './symmetric';
 
 const HANDSHAKE_RESEND_INTERVAL = 1000;
-const HANDSHAKE_TIMEOUT = 5000;
+const HANDSHAKE_TIMEOUT = 10000;
 
 enum HandshakeMode {
   START,


### PR DESCRIPTION
## Overview
This fix increases the timeout for the handshake process.
The issue (timeout) was presented when the app was packaged using the main lavamoat and ASAR enabled, intermittently in Linux and invariably on Windows.

