### PR TITLE
Add checksums to packaged apps

### DIFF
--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -153,9 +153,9 @@ jobs:
           path: artifacts
 
       - name: Get checksums (SHA512) from artifacts
-        run: find ./artifacts -type f -exec sha512sum {} \; | sed -e 's/ .*[/ ]/ /' > ./checksums.txt
+        run: find ./artifacts -type f -exec sha512sum {} \; | sed -e 's/ .*[/ ]/ /' > ./checksums-sha512.txt
 
       - uses: actions/upload-artifact@v3
         with:
           name: checksums
-          path: ./checksums.txt
+          path: ./checksums-sha512.txt

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -130,3 +130,32 @@ jobs:
           CSC_LINK: ${{ secrets.MMD_MAC_CSC_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.MMD_MAC_CSC_KEY_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packaged-apps
+          path: |
+            packages/app/packages/*.dmg
+            packages/app/packages/*.AppImage
+            packages/app/packages/*.exe
+
+  checksum:
+    name: Checksum packaged apps
+    runs-on: ubuntu-latest
+    needs: package-prod
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: packaged-apps
+          path: artifacts
+
+      - name: Get checksums (SHA512) from artifacts
+        run: find ./artifacts -type f -exec sha512sum {} \; | sed -e 's/ .*[/ ]/ /' > ./checksums.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: checksums
+          path: ./checksums.txt


### PR DESCRIPTION
# Context
When we publish installers, we also want to provide a checksum (SHA512) so that a user can verify that what they are downloading is genuine.

An additional layer could be provided by signing the file using openPGP (https://github.com/marketplace/actions/openpgp-action). We could also use the gpg command directly instead of relaying on an action. However, a key pair is required for that step.

Here's an example from a test repo of what the output will be. Using simple text files.

https://github.com/bergarces/test-github-actions/actions/runs/3884307740
https://github.com/bergarces/test-github-actions/actions/runs/3884307740/workflow

# Changes
* Upload packaged apps as artifacts in order to generate a checksum of the files. Then upload the checksum as well as an artifact.