### PR TITLE
fix: add PAT for submodule checkout

### DIFF
--- a/.github/workflows/package-app-dev.yml
+++ b/.github/workflows/package-app-dev.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          submodules: true
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - name: Setup submodule
-        shell: bash
-        run: yarn setup:submodule
       - name: Install deps
         shell: bash
         run: yarn install --frozen-lockfile

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -75,13 +75,13 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          submodules: true
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - name: Setup submodule
-        shell: bash
-        run: yarn setup:submodule
       - name: Install deps
         shell: bash
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
# Context
Currently the submodule repo is still private (we are using the mirror repo instead of the extension repo). This means that the default GITHUB_TOKEN available on the github action does not have permissions to check out the submodule repo. As a temporary solution we are using a PAT token from a user that has access to both repos.
(This should be removed as soon as we start using the Extension repo for the submodule)