### PR TITLE
Lavamoat fixes (aa for windows and domain taming)

### DIFF
--- a/packages/app/lavamoat/node/policy-override.json
+++ b/packages/app/lavamoat/node/policy-override.json
@@ -209,6 +209,26 @@
         "console.warn": false,
         "define": false
       }
+    },
+    "@metamask/permission-controller>nanoid": {
+      "builtin": {
+        "crypto": true
+      }
+    },
+    "@metamask/approval-controller>nanoid": {
+      "builtin": {
+        "crypto": true
+      }
+    },
+    "@metamask/notification-controller>nanoid": {
+      "builtin": {
+        "crypto": true
+      }
+    },
+    "@metamask/snaps-controllers>nanoid": {
+      "builtin": {
+        "crypto": true
+      }
     }
   }
 }

--- a/packages/app/lavamoat/node/policy.json
+++ b/packages/app/lavamoat/node/policy.json
@@ -859,6 +859,11 @@
         "eth-rpc-errors": true
       }
     },
+    "@metamask/approval-controller>nanoid": {
+      "builtin": {
+        "crypto": true
+      }
+    },
     "@metamask/assets-controllers": {
       "builtin": {
         "events.EventEmitter": true
@@ -1754,6 +1759,11 @@
         "@metamask/notification-controller>nanoid": true
       }
     },
+    "@metamask/notification-controller>nanoid": {
+      "builtin": {
+        "crypto": true
+      }
+    },
     "@metamask/obs-store": {
       "builtin": {
         "stream.Duplex": true
@@ -1787,6 +1797,11 @@
         "eth-rpc-errors": true,
         "immer": true,
         "json-rpc-engine": true
+      }
+    },
+    "@metamask/permission-controller>nanoid": {
+      "builtin": {
+        "crypto": true
       }
     },
     "@metamask/phishing-controller": {
@@ -2651,6 +2666,11 @@
       "packages": {
         "json-rpc-engine>@metamask/safe-event-emitter": true,
         "readable-stream": true
+      }
+    },
+    "@metamask/snaps-controllers>nanoid": {
+      "builtin": {
+        "crypto": true
       }
     },
     "@metamask/snaps-controllers>readable-web-to-node-stream": {

--- a/packages/app/lavamoat/ui/build-system/policy.json
+++ b/packages/app/lavamoat/ui/build-system/policy.json
@@ -6879,7 +6879,8 @@
         "path.relative": true
       },
       "globals": {
-        "performantResolve": true
+        "performantResolve": true,
+        "process.platform": true
       },
       "packages": {
         "brfs>resolve": true

--- a/packages/app/patches/@lavamoat+aa+3.1.0.patch
+++ b/packages/app/patches/@lavamoat+aa+3.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@lavamoat/aa/src/index.js b/node_modules/@lavamoat/aa/src/index.js
-index 070b772..7090bc8 100644
+index 070b772..d741c3a 100644
 --- a/node_modules/@lavamoat/aa/src/index.js
 +++ b/node_modules/@lavamoat/aa/src/index.js
 @@ -76,6 +76,7 @@ function getDependencies(packageDir, includeDevDeps) {
@@ -10,7 +10,7 @@ index 070b772..7090bc8 100644
      ...Object.keys(includeDevDeps ? packageJson.devDependencies || {} : {}),
    ].sort(comparePreferredPackageName)
    return depsToWalk
-@@ -156,6 +157,14 @@ function getPackageNameForModulePath(canonicalNameMap, modulePath) {
+@@ -156,6 +157,16 @@ function getPackageNameForModulePath(canonicalNameMap, modulePath) {
    const relativeToPackageDir = path.relative(packageDir, modulePath)
    // files should never be associated with a package directory across a package boundary (as tested via the presense of "node_modules" in the path)
    if (relativeToPackageDir.includes('node_modules')) {
@@ -18,7 +18,9 @@ index 070b772..7090bc8 100644
 +    // TO REMOVE ONCE WE DO NOT RELY ON EXTENSION NODE MODULES
 +    // Which is not the case until we have our own UI components and stop importing the extension ones.
 +    // This is happening because of how browserify lavamoat resolves require paths
-+    if (relativeToPackageDir.includes('submodules/extension/node_modules/')) {
++    const dirSeparator = process.platform === 'win32' ? '\\' : '/';
++    const nodeModulesPath = `submodules${dirSeparator}extension${dirSeparator}node_modules${dirSeparator}`;
++    if (relativeToPackageDir.includes(nodeModulesPath)) {
 +      return packageName;
 +    }
 +

--- a/packages/app/src/app/lavamoat.ts
+++ b/packages/app/src/app/lavamoat.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import { app } from 'electron';
 import { runLava } from 'lavamoat';
 
+// TODO Remove this whenever we solve the issue with domain builtin
+process.env.LOCKDOWN_DOMAIN_TAMING = 'unsafe';
+
 let appPath = process.cwd();
 const policyRelativePath = '/lavamoat/node/';
 


### PR DESCRIPTION
- Update `@lavamoat/aa` patch to work with Windows.
- Update lavamoat policies and required overrides.
- Set domain taming to unsafe to fix lavamoat breaking change.