### PR TITLE
fix: packaged app lavamoat policies

### DIFF
--- a/packages/app/lavamoat/node/policy-override.json
+++ b/packages/app/lavamoat/node/policy-override.json
@@ -251,6 +251,16 @@
       "globals": {
         "Buffer.allocUnsafe": true
       }
+    },
+    "lavamoat>@babel/highlight>chalk>supports-color": {
+      "packages": {
+        "lavamoat>@babel/highlight>chalk>supports-color>has-flag": true
+      }
+    },
+    "lavamoat>@babel/highlight>chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
+      }
     }
   }
 }

--- a/packages/app/lavamoat/node/policy.json
+++ b/packages/app/lavamoat/node/policy.json
@@ -7309,7 +7309,13 @@
         "process.versions.node.split": true
       },
       "packages": {
-        "@truffle/codec>debug>supports-color>has-flag": true
+        "@truffle/codec>debug>supports-color>has-flag": true,
+        "lavamoat>@babel/highlight>chalk>supports-color>has-flag": true
+      }
+    },
+    "lavamoat>@babel/highlight>chalk>supports-color>has-flag": {
+      "globals": {
+        "process.argv": true
       }
     },
     "lavamoat>bindings": {


### PR DESCRIPTION
# Context

Fiz lavamoat policies for packaged app.. For some reason, even if we are specifying lavamoat to only consider prod deps, it is computing the path to `supports-color>has-flag` differently 😅 