### PR TITLE
chore: add pipeline job to package for mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,13 @@ executors:
     environment:
       APP_DIR: << pipeline.parameters.app-dir >>
       EXTENSION_DIR: << pipeline.parameters.extension-dir >>
+  mac:
+    macos:
+      xcode: 12.5.1
+    resource_class: large
+    environment:
+      APP_DIR: << pipeline.parameters.app-dir >>
+      EXTENSION_DIR: << pipeline.parameters.extension-dir >>
 
 workflows:
   test_and_release:
@@ -127,6 +134,10 @@ workflows:
             - build-app
             - build-ui
       - package-linux:
+          requires:
+            - build-app
+            - build-ui
+      - package-mac:
           requires:
             - build-app
             - build-ui
@@ -582,7 +593,7 @@ jobs:
             mkdir -p ./${APP_DIR}/packages/artifacts
             mv ./${APP_DIR}/packages/metamask-desktop-*-setup.exe ./${APP_DIR}/packages/artifacts/
       - store_artifacts:
-          path: /root/project/packages/app/packages/artifacts
+          path: ./<< pipeline.parameters.app-dir >>/packages/artifacts
 
   package-linux:
     executor: electron-builder
@@ -608,4 +619,33 @@ jobs:
             mkdir -p ./${APP_DIR}/packages/artifacts
             mv ./${APP_DIR}/packages/metamask-desktop-*.AppImage ./${APP_DIR}/packages/artifacts/
       - store_artifacts:
-          path: /root/project/packages/app/packages/artifacts
+          path: ./<< pipeline.parameters.app-dir >>/packages/artifacts
+
+  package-mac:
+    executor: mac
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Move app build
+          command: |
+            mkdir -p ./${APP_DIR}/dist
+            mv ./${APP_DIR}/dist-app ./${APP_DIR}/dist/app
+      - run:
+          name: Move UI build
+          command: |
+            mv ./${APP_DIR}/dist-ui ./${APP_DIR}/dist/ui
+      - run:
+          name: Finalise dependencies
+          command: yarn
+      - run:
+          name: Package Mac images
+          command: yarn app package:mac -p "never"
+      - run:
+          name: Move executable to its own folder
+          command: |
+            mkdir -p ./${APP_DIR}/packages/artifacts
+            mv ./${APP_DIR}/packages/MetaMask*.dmg ./${APP_DIR}/packages/artifacts/
+      - store_artifacts:
+          path: ./<< pipeline.parameters.app-dir >>/packages/artifacts


### PR DESCRIPTION
# Overview

Create a CircleCI job to verify packaging for mac using a MacOS executor.