### PR TITLE
chore: support debug in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ package-lock.json
 
 # IDEs
 .idea
-.vscode
 .sublime-project
 *.bak
 
@@ -28,6 +27,11 @@ packages/**/coverage
 packages/**/playwright/playwright-reports
 packages/app/test-results
 .eslintcache
+
+# VSCode
+
+.vscode/*
+!.vscode/launch.json
 
 # Yarn
 .yarn/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Electron - Main Process",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/app",
+      "runtimeExecutable": "${workspaceFolder}/packages/app/node_modules/.bin/electron",
+      "runtimeArgs": ["--remote-debugging-port=9223"],
+      "program": "${workspaceFolder}/packages/app/src/app/main.ts",
+      "sourceMaps": true
+    },
+    {
+      "name": "Electron - Renderer Processes",
+      "type": "chrome",
+      "request": "attach",
+      "port": 9223,
+      "timeout": 30000,
+      "sourceMaps": true
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Electron - All",
+      "configurations": ["Electron - Main Process", "Electron - Renderer Processes"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you see "All set Fox" message displayed in your Desktop app, it means you're 
 
 Your MetaMask Desktop app now acts as a companion app for your Flask extension which shall improve its overall performance.
 
-## Other scripts
+## Other Scripts
 
 Run a script for a specific package:
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app\"",
-    "build:lavamoat": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn app build:ui:lavamoat\"  \"yarn app build:app\"",
+    "build:lavamoat": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension:lavamoat\" \"yarn app build:ui:lavamoat\"  \"yarn app build:app:prod\"",
     "build:test:app": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:test:desktop:app\" \"yarn app build:ui\"  \"yarn app build:app:test:app\"",
     "build:test:extension": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:test:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app:test:extension\"",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts npm yarn github.com codeload.github.com --empty-hostname true --allowed-schemes \"https:\" \"git+https:\" \"npm:\" \"patch:\" \"workspace:\"",

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -69,15 +69,16 @@ yarn app lint:fix
 
 ### Visual Studio Code
 
-This repository contains configuration to support debugging within Visual Studio Code.
+The repository contains configuration files to support debugging the app within Visual Studio Code.
+
+| Configuration | Description |
+| --- | --- |
+| Electron - Main Process | Debug only the main Electron process which handles requests from the extension. |
+| Electron - Renderer Processes | Debug only the Electron renderer processes which correspond to each Electron window. |
+| Electron - All | Debug the Electron main and renderer processes simultaneously. |
 
 1. Open the `Run and Debug` view.
-2. Run the desired configuration:
-   | Configuration | Description |
-   | --- | --- |
-   | Electron - Main Process | Debug only the main Electron process which handles requests from the extension. |
-   | Electron - Renderer Processes | Debug only the Electron renderer processes which correspond to each Electron window. |
-   | Electron - All | Debug the Electron main and renderer processes simultaneously. |
+2. Run the desired configuration.
 3. Add breakpoints to any desired source files.
 
 Note: _Source maps are used to support debugging with the original TypeScript files rather than any transpiled files in the `packages/app/dist` directory._
@@ -101,8 +102,8 @@ The below variables can be specified using a `.metamaskrc` file in the `packages
 | COMPATIBILITY_VERSION_DESKTOP | Override the compatibility version of the desktop app. |
 | COMPATIBILITY_VERSION_EXTENSION | Override the compatibility version of the extension. |
 | DESKTOP_UI_DEBUG | Set to `1` to enable the Chrome developer tools in the main Electron window. |
-| DISABLE_WEB_SOCKET_ENCRYPTION | Set this to `1` to disable all encryption when communicating with the desktop app. |
-| SKIP_OTP_PAIRING_FLOW | Set this to `1` to skip the pairing process when enabling desktop mode. |
+| DISABLE_WEB_SOCKET_ENCRYPTION | Set to `1` to disable all encryption when communicating with the desktop app. |
+| SKIP_OTP_PAIRING_FLOW | Set to `1` to skip the pairing process when enabling desktop mode. |
 
 ## Reset Electron State
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -1,47 +1,117 @@
 # MetaMask Desktop App
-### Prerequisites
 
-- Install [Node.js](https://nodejs.org) version 16
-    - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm use` will automatically choose the right node version for you.
-- Install [Yarn](https://yarnpkg.com/en/docs/install)
+This directory contains the MetaMask Desktop application, built with [Electron](https://www.electronjs.org/docs/latest), which can be paired with the Flask extension to improve its overall performance. 
 
-### Building locally
+## Getting Started
 
-- Install dependencies: `yarn setup` (not the usual install command)
-- Copy the `.metamaskrc.dist` file to `.metamaskrc`
-    - Replace the `INFURA_PROJECT_ID` value with your own personal [Infura Project ID](https://infura.io/docs).
-    - Optionally, replace the `PASSWORD` value with your development wallet password to avoid entering it each time you open the app.
-- Run `yarn build` to start development environment. (This will open up extension, desktop main process and desktop renderer process in watch mode)
-    - Run `yarn app start` to run the electron application.
+Build the [React](https://reactjs.org/) UI used by the Electron app:
 
-### Building locally with MV3 enabled
+```
+yarn app build:ui
+```
 
-- Install dependencies: `yarn setup` (not the usual install command)
-- Copy the `.metamaskrc.dist` file to `.metamaskrc`
-    - `ENABLE_MV3=true` is automatically set at build step.
-- Build the extension with desktop support using `yarn extension build:desktop:extension:mv3`.
-- Build the desktop app using `yarn app build:app:mv3`.
-    - Run `yarn app start` to run the desktop app.
+Build the Electron app:
 
-### Running Unit Tests and Linting
+```
+yarn app build:app
+```
 
-Run unit tests and the linter with `yarn test`. To run just unit tests, run `yarn test:unit`.
+Start the app:
 
-You can run the linter by itself with `yarn lint`, and you can automatically fix some lint problems with `yarn lint:fix`. You can also run these two commands just on your local changes to save time with `yarn lint:changed` and `yarn lint:changed:fix` respectively.
+```
+yarn app start
+```
 
-### Clear Electron app state data
+## Package
 
-Desktop UI persists data for the user settings and extension. To clear this data, run `yarn clear:electron-state`
+Generate a suitable installer package for a specific operating system:
 
-Note: _This will clear the data for all development Electron apps._
+| Platform | Type | Command |
+| --- | --- | --- |
+| Windows | NSIS Installer | `yarn app package:win` |
+| MacOS | DMG Image | `yarn app package:mac` |
+| Linux | AppImage | `yarn app package:linux` |
+
+## Test
+
+### Unit Tests
+
+```
+yarn app test
+```
+
+### E2E Tests
+
+Verify the behaviour of the extension when paired with the app:
+
+```
+yarn build:test:extension
+yarn app test:e2e:extension
+```
+
+To verify the behaviour of the app itself, see the [Playwright setup instructions](test/playwright/README.md).
+
+## Lint
+
+Check for linting issues:
+
+```
+yarn app lint
+```
+
+Attempt to automatically fix linting issues:
+
+```
+yarn app lint:fix
+```
+
+## Debug
+
+### Visual Studio Code
+
+This repository contains configuration to support debugging within Visual Studio Code.
+
+1. Open the `Run and Debug` view.
+2. Run the desired configuration:
+   | Configuration | Description |
+   | --- | --- |
+   | Electron - Main Process | Debug only the main Electron process which handles requests from the extension. |
+   | Electron - Renderer Processes | Debug only the Electron renderer processes which correspond to each Electron window. |
+   | Electron - All | Debug the Electron main and renderer processes simultaneously. |
+3. Add breakpoints to any desired source files.
+
+Note: _Source maps are used to support debugging with the original TypeScript files rather than any transpiled files in the `packages/app/dist` directory._
+
+### Chrome Developer Tools
+
+As each Electron window is ran in a Chrome instance, the Chrome developer tools can be used to debug the main renderer process.
+
+1. Set `DESKTOP_UI_DEBUG=1` in `packages/app/.metamaskrc` before building the UI.
+2. When in the main Electron window, press `Command / Control + Shift + I`.
+3. Use the `sources` tab to create breakpoints in any of the source files.
+
+## Configuration
+
+The below variables can be specified using a `.metamaskrc` file in the `packages/app` directory.
 
 ### Environment Variables
-
-#### Development
 
 | Name | Description |
 | ---  | --- |
 | COMPATIBILITY_VERSION_DESKTOP | Override the compatibility version of the desktop app. |
 | COMPATIBILITY_VERSION_EXTENSION | Override the compatibility version of the extension. |
+| DESKTOP_UI_DEBUG | Set to `1` to enable the Chrome developer tools in the main Electron window. |
 | DISABLE_WEB_SOCKET_ENCRYPTION | Set this to `1` to disable all encryption when communicating with the desktop app. |
 | SKIP_OTP_PAIRING_FLOW | Set this to `1` to skip the pairing process when enabling desktop mode. |
+
+## Reset Electron State
+
+The app persists data for both user preferences and extension state.
+
+To clear all persisted state:
+
+```
+yarn app clear:electron-state
+```
+
+Note: _This will remove data for all Electron apps ran in development mode._

--- a/packages/app/babel-app.config.js
+++ b/packages/app/babel-app.config.js
@@ -1,5 +1,6 @@
 module.exports = function (api) {
   const isUnitTest = api.env('test');
+  const isProd = api.env('production');
   api.cache(false);
   return {
     parserOpts: {
@@ -8,7 +9,7 @@ module.exports = function (api) {
     targets: {
       electron: '22',
     },
-    sourceMaps: 'inline',
+    sourceMaps: isProd ? false : 'inline',
     presets: [
       '@babel/preset-typescript',
       '@babel/preset-env',

--- a/packages/app/babel-app.config.js
+++ b/packages/app/babel-app.config.js
@@ -8,6 +8,7 @@ module.exports = function (api) {
     targets: {
       electron: '22',
     },
+    sourceMaps: 'inline',
     presets: [
       '@babel/preset-typescript',
       '@babel/preset-env',

--- a/packages/app/build/ui/scripts.js
+++ b/packages/app/build/ui/scripts.js
@@ -435,8 +435,12 @@ function setupSourcemaps(buildConfiguration, { buildTarget }) {
       // https://bugs.chromium.org/p/chromium/issues/detail?id=931675
       .push(
         isDevBuild(buildTarget)
-          ? sourcemaps.write()
-          : sourcemaps.write('./sourcemaps', { addComment: false }),
+          ? sourcemaps.write({
+              sourceRoot: '/packages/app/',
+            })
+          : sourcemaps.write('./sourcemaps', {
+              addComment: false,
+            }),
       );
   });
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/MetaMask/desktop",
   "scripts": {
     "build:app": "./build/build.sh",
+    "build:app:prod": "NODE_ENV=production yarn build:app",
     "build:app:test:extension": "IN_TEST=true SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' PHISHING_WARNING_PAGE_URL=http://localhost:9999/ METAMASK_DEBUG=1 yarn build:app",
     "build:app:test:app": "UI_TEST=true METAMASK_DEBUG=1 yarn build:app",
     "build:ui": "node build/ui/desktop-ui.js dev --apply-lavamoat=false",


### PR DESCRIPTION
# Overview

Add configurations to support debugging the main process and renderer processes in Visual Studio Code.

# Changes

## App

- Update README.
- Add `build:app:prod` package script to build the app with source maps disabled.