### PR TITLE
Add missing apple credentials

### DIFF
--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -121,3 +121,6 @@ jobs:
           CSC_LINK: ${{ secrets.MMD_MAC_CSC_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.MMD_MAC_CSC_KEY_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}


### PR DESCRIPTION
# Context
Add missing apple credentials to package-prod github action. This will allow successfully running the notarization process on the CI.