### PR TITLE
Fix tag name on draft release creation in package prod action

### DIFF
--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -61,7 +61,7 @@ jobs:
           PACKAGE_JSON="./packages/app/package.json"
           RELEASE_VERSION="$(jq --raw-output .version $PACKAGE_JSON)"
           echo "v@$RELEASE_VERSION"
-          gh release create "v$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d
+          gh release create "v$RELEASE_VERSION" -t "MetaMask Desktop v$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d
 
   package-prod:
     needs: publish-app-release-draft

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -61,7 +61,7 @@ jobs:
           PACKAGE_JSON="./packages/app/package.json"
           RELEASE_VERSION="$(jq --raw-output .version $PACKAGE_JSON)"
           echo "v@$RELEASE_VERSION"
-          gh release create "v@$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d
+          gh release create "v$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d
 
   package-prod:
     needs: publish-app-release-draft


### PR DESCRIPTION
# Context
Fix release tag naming for desktop app release. We need to have a strict name, because that is what electron-builder will look for in order to know if it should publish the packaged artifacts into an existing release or create another one as a draft. In this case we need the tag to be `v<RELEASE VERSION>`.

Also took the opportunity to explicitly set a release name when creating the draft release. Otherwise gh would just name it as `Draft`.