### PR TITLE
Add code licenses to the desktop repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/desktop.git"
+    "url": "https://github.com/MetaMask/metamask-desktop.git"
   },
   "scripts": {
     "build": "yarn common build && concurrently -n extension,ui,app  \"yarn extension build:desktop:extension\" \"yarn app build:ui\"  \"yarn app build:app\"",

--- a/packages/app/LICENSE
+++ b/packages/app/LICENSE
@@ -1,0 +1,18 @@
+Copyright ConsenSys Software Inc. 2022. All rights reserved.
+
+You acknowledge and agree that ConsenSys Software Inc. (“ConsenSys”) (or ConsenSys’s licensors) own all legal right, title and interest in and to the work, software, application, source code, documentation and any other documents in this repository (collectively, the “Program”), including any intellectual property rights which subsist in the Program (whether those rights happen to be registered or not, and wherever in the world those rights may exist), whether in source code or any other form.
+
+Subject to the limited license below, you may not (and you may not permit anyone else to) distribute, publish, copy, modify, merge, combine with another program, create derivative works of, reverse engineer, decompile or otherwise attempt to extract the source code of, the Program or any part thereof, except that you may contribute to this repository.
+
+You are granted a non-exclusive, non-transferable, non-sublicensable license to distribute, publish, copy, modify, merge, combine with another program or create derivative works of the Program (such resulting program, collectively, the “Resulting Program”) solely for Non-Commercial Use as long as you:
+ 1. give prominent notice (“Notice”) with each copy of the Resulting Program that the Program is used in the Resulting Program and that the Program is the copyright of ConsenSys; and
+ 2. subject the Resulting Program and any distribution, publication, copy, modification, merger therewith, combination with another program or derivative works thereof to the same Notice requirement and Non-Commercial Use restriction set forth herein.
+
+“Non-Commercial Use” means each use as described in clauses (1)-(3) below, as reasonably determined by ConsenSys in its sole discretion:
+ 1. personal use for research, personal study, private entertainment, hobby projects or amateur pursuits, in each case without any anticipated commercial application;
+ 2. use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization or government institution; or
+ 3. the number of monthly active users of the Resulting Program across all versions thereof and platforms globally do not exceed 10,000 at any time.
+
+You will not use any trade mark, service mark, trade name, logo of ConsenSys or any other company or organization in a way that is likely or intended to cause confusion about the owner or authorized user of such marks, names or logos.
+
+If you have any questions, comments or interest in pursuing any other use cases, please reach out to us at communications@metamask.io.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.2",
   "private": true,
   "main": "dist/app/src/app/lavamoat.js",
-  "repository": "https://github.com/MetaMask/desktop",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/metamask-desktop.git"
+  },
   "scripts": {
     "build:app": "./build/build.sh",
     "build:app:prod": "NODE_ENV=production yarn build:app",

--- a/packages/common/LICENSE
+++ b/packages/common/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,10 +2,16 @@
   "name": "@metamask/desktop",
   "version": "0.1.1",
   "main": "dist/index.js",
+  "description": "Functions and classes needed to work with MetaMask Desktop",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/desktop.git"
+    "url": "https://github.com/MetaMask/metamask-desktop.git"
   },
+  "bugs": {
+    "url": "https://github.com/MetaMask/metamask-desktop/issues"
+  },
+  "homepage": "https://github.com/MetaMask/metamask-desktop/tree/main/packages/common",
+  "license": "MIT",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
# Context
Add the code licenses for both desktop app and common package.

# Changes
## Common
* Add MIT license
* Update package.json with relevant information for npm

## App
* Add proprietary license (same one that is used on MetaMask Extension)
* Update package.json repository url to target the rename (`desktop` -> `metamask-desktop`)

## Repo root
* Update package.json repository url to target the rename (`desktop` -> `metamask-desktop`)