### PR TITLE
fix: gh release to target app-stable branch

### DIFF
--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -61,7 +61,7 @@ jobs:
           PACKAGE_JSON="./packages/app/package.json"
           RELEASE_VERSION="$(jq --raw-output .version $PACKAGE_JSON)"
           echo "v@$RELEASE_VERSION"
-          gh release create "v$RELEASE_VERSION" -t "MetaMask Desktop v$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d
+          gh release create "v$RELEASE_VERSION" -t "MetaMask Desktop v$RELEASE_VERSION" -F packages/app/CHANGELOG.md -d --target app-stable
 
   package-prod:
     needs: publish-app-release-draft


### PR DESCRIPTION
# Context
Update the desktop app create draft release job to target the `app-stable` branch instead of `main`.