### PR TITLE
fix: persist metametrics opt in value

### DIFF
--- a/packages/app/src/app/app-events.ts
+++ b/packages/app/src/app/app-events.ts
@@ -3,7 +3,7 @@ import cfg from '../utils/config';
 import { determineLoginItemSettings } from '../utils/settings';
 import AppNavigation from './app-navigation';
 import UIState from './ui-state';
-import { getPreferredStartupState } from './ui-storage';
+import { readPersistedSettingFromAppState } from './ui-storage';
 
 export default class AppEvents {
   public appNavigation: AppNavigation;
@@ -27,7 +27,10 @@ export default class AppEvents {
 
     // Set preferred startup setting
     if (!cfg().ui.preventOpenOnStartup) {
-      const preferredStartup = getPreferredStartupState();
+      const preferredStartup = readPersistedSettingFromAppState({
+        defaultValue: 'minimized',
+        key: 'preferredStartup',
+      });
       app.setLoginItemSettings(determineLoginItemSettings(preferredStartup));
     }
 

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -1,6 +1,6 @@
 import { Duplex, EventEmitter } from 'stream';
 import path from 'path';
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import { Server as WebSocketServer, WebSocket } from 'ws';
 import log from 'loglevel';
@@ -109,6 +109,10 @@ class DesktopApp extends EventEmitter {
     ipcMain.handle('set-theme', (event, theme) => {
       const win = BrowserWindow.fromWebContents(event.sender);
       win?.setTitleBarOverlay?.(titleBarOverlayOpts[theme]);
+    });
+
+    ipcMain.handle('open-external', (_event, link) => {
+      shell.openExternal(link);
     });
 
     if (!cfg().ui.preventOpenOnStartup) {
@@ -225,6 +229,10 @@ class DesktopApp extends EventEmitter {
       'connect-remote',
       'connect-external',
     ]);
+
+    if (this.status.isDesktopPaired) {
+      this.appNavigation.setPairedTrayIcon();
+    }
 
     // if a connection is active it should set new connection as on hold
     // so the user unpair properly before establishing a new connection

--- a/packages/app/src/app/renderer/preload.ts
+++ b/packages/app/src/app/renderer/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer, shell } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 
 const uiStoreBridge = (name: string) => {
   return {
@@ -51,7 +51,7 @@ const electronBridge = {
     await ipcRenderer.invoke('set-theme', themeCode);
   },
   openExternalShell: async (link: string) => {
-    await shell.openExternal(link);
+    await ipcRenderer.invoke('open-external', link);
   },
   setPreferredStartup: async (preferredStartup: string) => {
     await ipcRenderer.invoke('set-preferred-startup', preferredStartup);

--- a/packages/app/src/app/window-service.ts
+++ b/packages/app/src/app/window-service.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow } from 'electron';
 import log from 'loglevel';
 import UIState from './ui-state';
 import { titleBarOverlayOpts } from './ui-constants';
+import { readPersistedSettingFromAppState } from './ui-storage';
 
 export default class WindowService {
   private UIState: typeof UIState;
@@ -32,9 +33,18 @@ export default class WindowService {
       mainWindow?.setMenu(null);
     }
 
+    const isMetametricsOptionSelected = readPersistedSettingFromAppState({
+      defaultValue: false,
+      key: 'isMetametricsOptionSelected',
+    });
+
+    const startupPage = isMetametricsOptionSelected
+      ? 'pair'
+      : 'metametrics-opt-in';
+
     mainWindow.loadFile(
       path.resolve(__dirname, '../../../ui/desktop-ui.html'),
-      { hash: 'pair' },
+      { hash: startupPage },
     );
 
     log.debug('Created main window');

--- a/packages/app/test/playwright/specs/desktop.connectivity.spec.ts
+++ b/packages/app/test/playwright/specs/desktop.connectivity.spec.ts
@@ -52,6 +52,7 @@ test.describe('Extension / Desktop connectivity issues', () => {
       electronApp,
       'MetaMask Desktop',
     );
+    await mainWindow.locator('text=No thanks').click();
     const otpWindow = new DesktopOTPPage(mainWindow);
 
     const extensionId = await signUpFlow(page, context);
@@ -86,6 +87,7 @@ test.describe('Extension / Desktop connectivity issues', () => {
       electronApp,
       'MetaMask Desktop',
     );
+    await mainWindow.locator('text=No thanks').click();
     const desktopWindow = new DesktopOTPPage(mainWindow);
 
     // BROWSER SESSION 1 START

--- a/packages/app/test/playwright/specs/desktop.pairing.spec.ts
+++ b/packages/app/test/playwright/specs/desktop.pairing.spec.ts
@@ -16,6 +16,7 @@ test.describe('Desktop OTP pairing', () => {
       electronApp,
       'MetaMask Desktop',
     );
+    await mainWindow.locator('text=No thanks').click();
     const otpWindow = new DesktopOTPPage(mainWindow);
 
     const extensionId = await signUpFlow(page, context);
@@ -44,6 +45,7 @@ test.describe('Desktop OTP pairing', () => {
       electronApp,
       'MetaMask Desktop',
     );
+    await mainWindow.locator('text=No thanks').click();
     const otpWindow = new DesktopOTPPage(mainWindow);
 
     const extensionId = await signUpFlow(page, context);

--- a/packages/app/test/playwright/specs/desktop.sync.spec.ts
+++ b/packages/app/test/playwright/specs/desktop.sync.spec.ts
@@ -20,6 +20,7 @@ test.describe('Desktop State Sync', () => {
       electronApp,
       'MetaMask Desktop',
     );
+    await mainWindow.locator('text=No thanks').click();
     const otpWindow = new DesktopOTPPage(mainWindow);
 
     const extensionId = await signUpFlow(page, context);

--- a/packages/app/ui/ducks/app/app.js
+++ b/packages/app/ui/ducks/app/app.js
@@ -4,6 +4,7 @@ export const initialAppState = {
   theme: 'os',
   language: 'en',
   metametricsOptIn: false,
+  isMetametricsOptionSelected: false,
   preferredStartup: 'minimized',
 };
 
@@ -35,6 +36,7 @@ export default function appReducer(state = initialAppState, action) {
       return {
         ...state,
         metametricsOptIn: action.payload,
+        isMetametricsOptionSelected: true,
       };
     }
 

--- a/packages/app/ui/locales/de.json
+++ b/packages/app/ui/locales/de.json
@@ -35,14 +35,14 @@
   "os": {
     "message": "System"
   },
+  "pairWithExtension": {
+    "message": "Mit Erweiterung synchronisieren"
+  },
   "settings": {
     "message": "Einstellungen"
   },
   "status": {
     "message": "Status"
-  },
-  "syncWithExtension": {
-    "message": "Mit Erweiterung synchronisieren"
   },
   "temporaryPairLink": {
     "message": "Temporary Pair Page Link"

--- a/packages/app/ui/locales/en.json
+++ b/packages/app/ui/locales/en.json
@@ -8,9 +8,6 @@
   "agree": {
     "message": "I agree"
   },
-  "allSetFox": {
-    "message": "All set, fox"
-  },
   "allowOpenAtLoginDescription": {
     "message": "Allow MetaMask Desktop to open when you log in to your computer"
   },
@@ -173,6 +170,9 @@
   "on": {
     "message": "ON"
   },
+  "openAtLogin": {
+    "message": "Open at Login"
+  },
   "os": {
     "message": "System"
   },
@@ -184,6 +184,12 @@
   },
   "pairNow": {
     "message": "Pair with your MetaMask extension"
+  },
+  "pairWithExtension": {
+    "message": "Pair with Extension"
+  },
+  "pairingComplete": {
+    "message": "Pairing complete!"
   },
   "participateInMetaMetrics": {
     "message": "Participate in MetaMetrics"
@@ -207,16 +213,13 @@
     "message": "Settings"
   },
   "someExplainer": {
-    "message": "Some explainer about using the extension as usual but keep this app open and check the alerts."
+    "message": "Be sure to enter your password in MetaMask Extension. Keep this app open to see any alerts that you might receive."
   },
   "status": {
     "message": "Status"
   },
   "supportCenter": {
     "message": "Visit our support center"
-  },
-  "syncWithExtension": {
-    "message": "Sync with Extension"
   },
   "temporaryPairLink": {
     "message": "Temporary Pair Page Link"
@@ -228,7 +231,7 @@
     "message": "Theme"
   },
   "typeTheSixDigitCodeBelow": {
-    "message": "Open your MetaMask Extension and type the six-digit code below."
+    "message": "Enter the six-digit code visible on the MetaMask Extension screen"
   },
   "visitWebSite": {
     "message": "Visit our website"

--- a/packages/app/ui/pages/pair/pair.component.js
+++ b/packages/app/ui/pages/pair/pair.component.js
@@ -99,7 +99,7 @@ const Pair = ({ isDesktopPaired, isSuccessfulPairSeen, history }) => {
           height="150"
         />
         <Typography variant={TYPOGRAPHY.H3} fontWeight={FONT_WEIGHT.BOLD}>
-          {t('syncWithExtension')}
+          {t('pairWithExtension')}
         </Typography>
         <Typography variant={TYPOGRAPHY.Paragraph} fontSize={14}>
           {t('typeTheSixDigitCodeBelow')}

--- a/packages/app/ui/pages/successful-pair/successful-pair.component.js
+++ b/packages/app/ui/pages/successful-pair/successful-pair.component.js
@@ -43,7 +43,7 @@ const SuccessfulPair = ({
         height="150"
       />
       <Typography variant={TYPOGRAPHY.H3} fontWeight={FONT_WEIGHT.BOLD}>
-        {t('allSetFox')}
+        {t('pairingComplete')}
       </Typography>
       <Typography
         className="description"


### PR DESCRIPTION
## Overview
- Persists the opt-in value of MetaMetrics
- Depending on the persisted state of MetaMetrics, app opens either Metametrics or Pair page
- Fixes external links to open links on the main process
- Fixes tray bar icon change on restoring the connection 
- Fixes e2e test due to changes on the opening screen order 
- Fixes translations 