### PR TITLE
fix: hide window on cmd+q and implement warning dialog while desktop …

### DIFF
--- a/packages/app/src/app/app-events.test.ts
+++ b/packages/app/src/app/app-events.test.ts
@@ -1,5 +1,4 @@
-import process from 'process';
-import { app, globalShortcut } from 'electron';
+import { app } from 'electron';
 import { mockFilteredNodeEvent } from '../../test/utils';
 import AppEvents from './app-events';
 
@@ -23,7 +22,6 @@ jest.mock(
 
 describe('App Events', () => {
   const electronAppMock = app as jest.Mocked<any>;
-  const globalShortcutMock = globalShortcut as jest.Mocked<any>;
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -87,24 +85,6 @@ describe('App Events', () => {
     mockFilteredNodeEvent(electronAppMock, 'on', 'before-quit');
     appEvents.register();
 
-    expect(appEvents.UIState.forceQuit).toBe(true);
-  });
-
-  it('should quit once CMD + Q pressed on MacOS', () => {
-    // Manually set process.platform to darwin
-    // eslint-disable-next-line
-    // @ts-ignore
-    delete process.platform;
-    // eslint-disable-next-line
-    // @ts-ignore
-    process.platform = 'darwin';
-    const appQuitMock = jest.fn();
-    app.quit = appQuitMock;
-    const appEvents = new AppEvents();
-    mockFilteredNodeEvent(globalShortcutMock, 'register', 'Command+Q');
-
-    appEvents.register();
-    expect(appQuitMock).toHaveBeenCalled();
     expect(appEvents.UIState.forceQuit).toBe(true);
   });
 

--- a/packages/app/src/app/app-events.ts
+++ b/packages/app/src/app/app-events.ts
@@ -82,8 +82,7 @@ export default class AppEvents {
   }
 
   private onCmdQPressed() {
-    this.UIState.forceQuit = true;
-    app.quit();
+    this.UIState.mainWindow?.hide?.();
   }
 
   private onWindowClose(event: any) {

--- a/packages/app/src/app/app-navigation.ts
+++ b/packages/app/src/app/app-navigation.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { app, Tray, Menu, shell } from 'electron';
+import { app, Tray, Menu, shell, dialog } from 'electron';
+import { getDesktopState } from '@metamask/desktop/dist/utils/state';
 import {
   metamaskDesktopAboutWebsite,
   metamaskDesktopSubmitTicket,
@@ -80,7 +81,26 @@ export default class AppNavigation {
   private createQuitMenuItem() {
     return {
       label: 'Quit',
-      click: () => {
+      click: async () => {
+        const isDesktopPaired =
+          (await getDesktopState()).desktopEnabled === true;
+        if (isDesktopPaired) {
+          const { response: forceExit } = await dialog.showMessageBox({
+            type: 'warning',
+            buttons: ['Ok', 'Exit'],
+            cancelId: 0,
+            defaultId: 1,
+            icon: path.resolve(__dirname, '../../dist/app/icon.png'),
+            title: 'Warning',
+            message:
+              'MetaMask Extension is paired with MetaMask Desktop in the background. To quit, click Exit.',
+          });
+          if (forceExit) {
+            this.UIState.forceQuit = true;
+            app.quit();
+          }
+          return;
+        }
         this.UIState.forceQuit = true;
         app.quit();
       },


### PR DESCRIPTION
## Overview
- Change behaviour of CMD+Q, hides window when it's pressed
- Shows dialog to user and asks if they want to quit (only if desktop is enabled) 
![Screenshot 2023-01-23 at 12 41 41](https://user-images.githubusercontent.com/7644512/214031764-668a1905-adec-4490-af30-5163d8502539.png)
