### PR TITLE
fix: improve initial boot of app

### DIFF
--- a/packages/app/build/ui/scripts.js
+++ b/packages/app/build/ui/scripts.js
@@ -265,6 +265,13 @@ function createFactoredBuild({
               commonSet,
               applyLavaMoat,
             });
+
+            renderHtmlFile({
+              htmlName: 'desktop-ui-dark',
+              groupSet,
+              commonSet,
+              applyLavaMoat,
+            });
             break;
           }
 

--- a/packages/app/html/desktop-ui-dark.html
+++ b/packages/app/html/desktop-ui-dark.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html data-testid="main-app" data-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
+    <title>MetaMask Desktop</title>
+    <link rel="stylesheet" type="text/css" href="./index.css" title="ltr">
+    <link rel="stylesheet" type="text/css" href="./index-rtl.css" title="rtl" disabled>
+  </head>
+  <body>
+    <div id="mmd-draggable-hidden-bar"></div>
+    <div id="mmd-root"></div>
+    {{@if(it.applyLavaMoat)}}
+      <script src="./runtime-lavamoat.js" type="text/javascript" charset="utf-8"></script>
+      <script src="./lockdown-more.js" type="text/javascript" charset="utf-8"></script>
+      <script src="./policy-load.js" type="text/javascript" charset="utf-8"></script>
+    {{#else}}
+      <script src="./lockdown-install.js" type="text/javascript" charset="utf-8"></script>
+      <script src="./lockdown-run.js" type="text/javascript" charset="utf-8"></script>
+      <script src="./lockdown-more.js" type="text/javascript" charset="utf-8"></script>
+      <script src="./runtime-cjs.js" type="text/javascript" charset="utf-8"></script>
+    {{/if}}
+    {{@each(it.jsBundles) => val}}
+      <script src="{{val}}" type="text/javascript" charset="utf-8"></script>
+    {{/each}}
+  </body>
+</html>

--- a/packages/app/src/app/ui-storage.ts
+++ b/packages/app/src/app/ui-storage.ts
@@ -71,7 +71,7 @@ export const readPersistedSettingFromAppState = ({
   const value = persistedAppState[key];
 
   if (value) {
-    return value;
+    return JSON.parse(value);
   }
 
   log.info(

--- a/packages/app/ui/css/index.scss
+++ b/packages/app/ui/css/index.scss
@@ -1,3 +1,23 @@
+@import '../../submodules/extension/ui/css/reset.scss';
+@import '../../submodules/extension/ui/css/design-system/index';
+@import '../../submodules/extension/ui/css/utilities/colors.scss';
+@import '../../submodules/extension/ui/css/base-styles.scss';
+@import '../../submodules/extension/ui/css/itcss/settings/index';
+@import '../../node_modules/@metamask/design-tokens/src/css/design-tokens';
+
+// Imported partials
+// @import '../../submodules/extension/ui/components/app/app-components';
+@import '../../submodules/extension/ui/components/app/tab-bar/index.scss';
+
+// Imported partials
+// @import '../../submodules/extension/ui/components/ui/ui-components';
+@import '../../submodules/extension/ui/components/ui/button/buttons.scss';
+@import '../../submodules/extension/ui/components/ui/chip/chip.scss';
+@import '../../submodules/extension/ui/components/ui/typography/typography.scss';
+@import '../../submodules/extension/ui/components/ui/box/box.scss';
+@import '../../submodules/extension/ui/components/ui/dropdown/dropdown.scss';
+@import '../../submodules/extension/ui/components/ui/toggle-button/index.scss';
+
 $title-bar-height: 32px;
 
 body {
@@ -26,6 +46,5 @@ body {
   background-color: var(--color-background-default);
 }
 
-@import '../../submodules/extension/ui/css/index.scss';
 @import '../pages/mmd-pages.scss';
 @import '../components/mmd-components.scss';


### PR DESCRIPTION
## Overview
- Removed unusued CSS (from 1.5MB css to 500kb) 
- Prevent flickering white screen by using either dark or light themed HTML
- Taking advantage of ready-to-show BrowserWindow event