### PR TITLE
feat: send events saved before users opt-in

### DIFF
--- a/packages/app/src/app/controller-init.test.ts
+++ b/packages/app/src/app/controller-init.test.ts
@@ -4,6 +4,16 @@ import { AppDesktopController } from './controller-init';
 
 jest.mock('./desktop-app');
 
+jest.mock(
+  'electron',
+  () => ({
+    ipcMain: { handle: jest.fn() },
+  }),
+  {
+    virtual: true,
+  },
+);
+
 describe('App Desktop Controller', () => {
   const desktopAppMock = desktopApp as jest.Mocked<typeof desktopApp>;
   const extensionConnectionMock = createExtensionConnectionMock();

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -19,7 +19,6 @@ import { forwardEvents } from './utils/events';
 import { determineLoginItemSettings } from './utils/settings';
 import cfg from './utils/config';
 import { getDesktopVersion } from './utils/version';
-import { Properties } from './types/metrics';
 import ExtensionConnection from './extension-connection';
 import { updateCheck } from './update-check';
 import {
@@ -127,13 +126,6 @@ class DesktopApp extends EventEmitter {
     ipcMain.handle('open-external', (_event, link) => {
       shell.openExternal(link);
     });
-
-    ipcMain.handle(
-      'analytics-track',
-      (_event, eventName: string, properties: Properties) => {
-        this.metricsService.track(eventName, properties);
-      },
-    );
 
     if (!cfg().ui.preventOpenOnStartup) {
       ipcMain.handle('set-preferred-startup', (_event, preferredStartup) => {

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -19,6 +19,7 @@ import { forwardEvents } from './utils/events';
 import { determineLoginItemSettings } from './utils/settings';
 import cfg from './utils/config';
 import { getDesktopVersion } from './utils/version';
+import { Properties } from './types/metrics';
 import ExtensionConnection from './extension-connection';
 import { updateCheck } from './update-check';
 import {
@@ -126,6 +127,13 @@ class DesktopApp extends EventEmitter {
     ipcMain.handle('open-external', (_event, link) => {
       shell.openExternal(link);
     });
+
+    ipcMain.handle(
+      'analytics-track',
+      (_event, eventName: string, properties: Properties) => {
+        this.metricsService.track(eventName, properties);
+      },
+    );
 
     if (!cfg().ui.preventOpenOnStartup) {
       ipcMain.handle('set-preferred-startup', (_event, preferredStartup) => {

--- a/packages/app/src/app/main.ts
+++ b/packages/app/src/app/main.ts
@@ -13,12 +13,14 @@ import { LedgerBridgeKeyring as LedgerKeyring } from './hw/ledger/ledger-keyring
 import TrezorKeyring from './hw/trezor/trezor-keyring';
 import LatticeKeyring from './hw/lattice/lattice-keyring';
 import DesktopApp from './desktop-app';
+import metricsService from './metrics/metrics-service';
+import { EVENT_NAMES } from './metrics/metrics-constants';
 
 /**
  * TODO
  * Gets user the preferred language code.
  *
- * @returns The laguange code to be used for the app localisation. Defaults to 'en'.
+ * @returns The language code to be used for the app localisation. Defaults to 'en'.
  */
 const getFirstPreferredLangCode = () => {
   return 'en';
@@ -109,6 +111,7 @@ const onDesktopRestart = async (desktopApp: typeof DesktopApp) => {
  * Initialize desktop app.
  */
 const initDesktopApp = async () => {
+  metricsService.track(EVENT_NAMES.DESKTOP_APP_STARTING);
   await DesktopApp.init();
   DesktopApp.on('restart', () => onDesktopRestart(DesktopApp));
 };

--- a/packages/app/src/app/metrics/analytics.test.ts
+++ b/packages/app/src/app/metrics/analytics.test.ts
@@ -40,4 +40,31 @@ describe('Analytics', () => {
       ...message,
     });
   });
+
+  it('calls page on the analytics-node instance', () => {
+    const spy = jest.spyOn(analytics, 'page');
+    const message = {
+      name: EVENT_NAME_MOCK,
+      userId: UUID_MOCK,
+      properties: PROPERTIES_OBJECT_MOCK,
+      messageId: UUID_MOCK,
+    };
+    analytics.page(message);
+    expect(spy).toHaveBeenCalledWith({
+      ...message,
+    });
+  });
+
+  it('calls screen on the analytics-node instance', () => {
+    const spy = jest.spyOn(analytics, 'screen');
+    const message = {
+      name: EVENT_NAME_MOCK,
+      userId: UUID_MOCK,
+      properties: PROPERTIES_OBJECT_MOCK,
+    };
+    analytics.screen(message);
+    expect(spy).toHaveBeenCalledWith({
+      ...message,
+    });
+  });
 });

--- a/packages/app/src/app/metrics/analytics.ts
+++ b/packages/app/src/app/metrics/analytics.ts
@@ -16,7 +16,10 @@ class Analytics {
       context?: any;
     },
   ): void {
-    Analytics.instance.identify({ ...message, timestamp: new Date() });
+    Analytics.instance.identify({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
   }
 
   public track(
@@ -27,7 +30,40 @@ class Analytics {
       context?: any;
     },
   ): void {
-    Analytics.instance.track({ ...message, timestamp: new Date() });
+    Analytics.instance.track({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
+  }
+
+  public page(
+    message: Identity & {
+      category?: string | undefined;
+      name?: string | undefined;
+      properties?: any;
+      timestamp?: Date | undefined;
+      context?: any;
+      messageId?: string | undefined;
+    },
+  ): void {
+    Analytics.instance.page({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
+  }
+
+  public screen(
+    message: Identity & {
+      name?: string | undefined;
+      properties?: any;
+      timestamp?: Date | undefined;
+      context?: any;
+    },
+  ): void {
+    Analytics.instance.screen({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
   }
 
   private init = () => {

--- a/packages/app/src/app/metrics/metrics-constants.ts
+++ b/packages/app/src/app/metrics/metrics-constants.ts
@@ -7,3 +7,9 @@ export const EVENT_NAMES = {
   METRICS_OPT_OUT: 'Metrics Opt Out',
   INVALID_OTP: 'Invalid OTP',
 };
+
+export enum MetricsDecision {
+  ENABLED = 'ENABLED',
+  DISABLED = 'DISABLED',
+  PENDING = 'PENDING',
+}

--- a/packages/app/src/app/metrics/metrics-constants.ts
+++ b/packages/app/src/app/metrics/metrics-constants.ts
@@ -6,6 +6,9 @@ export const EVENT_NAMES = {
   METRICS_OPT_IN: 'Metrics Opt In',
   METRICS_OPT_OUT: 'Metrics Opt Out',
   INVALID_OTP: 'Invalid OTP',
+  DESKTOP_APP_STARTING: 'Desktop App Starting',
+  DESKTOP_UI_LOADED: 'Desktop UI Loaded',
+  UI_CRITICAL_ERROR: 'Desktop UI Critical Error',
 };
 
 export enum MetricsDecision {

--- a/packages/app/src/app/metrics/metrics-constants.ts
+++ b/packages/app/src/app/metrics/metrics-constants.ts
@@ -5,4 +5,5 @@ export const EVENT_NAMES = {
   DESKTOP_APP_PAIRED: 'Desktop App Paired',
   METRICS_OPT_IN: 'Metrics Opt In',
   METRICS_OPT_OUT: 'Metrics Opt Out',
+  INVALID_OTP: 'Invalid OTP',
 };

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -10,7 +10,7 @@ import MetricsService from './metrics-service';
 import Analytics from './analytics';
 
 jest.mock(
-  '../ui-storage',
+  '../storage/ui-storage',
   () => ({
     readPersistedSettingFromAppState: jest.fn().mockReturnValueOnce(true),
   }),

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../test/mocks';
 import MetricsService from './metrics-service';
 import Analytics from './analytics';
+import { MetricsDecision } from './metrics-constants';
 
 jest.mock(
   '../storage/ui-storage',
@@ -30,7 +31,7 @@ jest.mock(
               return true;
             case 'segmentApiCalls':
               return {};
-            case 'eventsBeforeMetricsOptIn':
+            case 'eventsSavedBeforeMetricsDecision':
               return [];
             default:
               return undefined;
@@ -62,7 +63,7 @@ describe('MetricsService', () => {
   let analytics: typeof Analytics;
   let trackSpy: any;
   let identifySpy: any;
-  let checkParticipateInDesktopMetricsSpy: any;
+  let getMetricsDecisionSpy: any;
   const electronStoreConstructorMock = Store as jest.MockedClass<typeof Store>;
   const storeMock = createElectronStoreMock();
 
@@ -73,9 +74,9 @@ describe('MetricsService', () => {
     electronStoreConstructorMock.mockReturnValue(storeMock);
     trackSpy = jest.spyOn(analytics, 'track');
     identifySpy = jest.spyOn(analytics, 'identify');
-    checkParticipateInDesktopMetricsSpy = jest.spyOn(
+    getMetricsDecisionSpy = jest.spyOn(
       metricsService as any,
-      'checkParticipateInDesktopMetrics',
+      'getMetricsDecision',
     );
   });
 
@@ -101,7 +102,7 @@ describe('MetricsService', () => {
     });
   });
 
-  it('tracks an event before users opt-in and store it in eventsBeforeMetricsOptIn', () => {
+  it('tracks an event before users opted in and store it in eventsSavedBeforeMetricsDecision', () => {
     metricsService.track(EVENT_NAME_MOCK, PROPERTIES_OBJECT_MOCK);
 
     expect(trackSpy).toHaveBeenCalledTimes(0);
@@ -128,7 +129,7 @@ describe('MetricsService', () => {
 
   it('should not call identify when the user has opted out', () => {
     const traits = PROPERTIES_OBJECT_MOCK;
-    checkParticipateInDesktopMetricsSpy.mockReturnValue(false);
+    getMetricsDecisionSpy.mockReturnValue(MetricsDecision.DISABLED);
 
     metricsService.identify(traits);
 

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -95,14 +95,10 @@ class MetricsService {
   }
 
   private checkParticipateInDesktopMetrics(): boolean | undefined {
-    const desktopMetricsOptInValue = readPersistedSettingFromAppState({
+    const desktopMetricsOptIn = readPersistedSettingFromAppState({
       defaultValue: undefined,
       key: 'metametricsOptIn',
     });
-    const desktopMetricsOptIn =
-      typeof desktopMetricsOptInValue === 'string'
-        ? desktopMetricsOptInValue === 'true'
-        : desktopMetricsOptInValue;
 
     // Flush events saved before user opt-in
     if (desktopMetricsOptIn && this.eventsBeforeMetricsOptIn?.length > 0) {
@@ -119,6 +115,7 @@ class MetricsService {
     });
 
     this.eventsBeforeMetricsOptIn = [];
+    this.store.set('eventsBeforeMetricsOptIn', []);
   }
 
   private saveCallSegmentAPI(event: Event) {

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -1,21 +1,23 @@
 import Store from 'electron-store';
 import { uuid } from '@metamask/desktop/dist/utils/utils';
 import log from 'loglevel';
-import { app } from 'electron';
+import { app, ipcMain } from 'electron';
 import { getDesktopVersion } from '../utils/version';
 import {
-  MetricsState,
+  MetricsStorage,
   Properties,
-  SegmentApiCalls,
   Traits,
   Event,
+  EventsStorage,
 } from '../types/metrics';
 import { readPersistedSettingFromAppState } from '../storage/ui-storage';
 import Analytics from './analytics';
 import { MetricsDecision } from './metrics-constants';
 
 class MetricsService {
-  private store: Store<MetricsState>;
+  private store: Store<MetricsStorage>;
+
+  private eventStore: Store<EventsStorage>;
 
   private analytics: typeof Analytics;
 
@@ -28,12 +30,13 @@ class MetricsService {
   // Traits are pieces of information you know about a user that are included in an identify call
   private traits: Traits;
 
-  // Every event submitted to segment
-  private segmentApiCalls: SegmentApiCalls;
+  // Tracks first time events
+  private processedEvents: string[];
 
   constructor() {
     this.analytics = Analytics;
-    this.store = new Store<MetricsState>({
+
+    this.store = new Store<MetricsStorage>({
       name: `mmd-desktop-metrics`,
     });
 
@@ -43,11 +46,23 @@ class MetricsService {
       [],
     );
     this.traits = this.store.get('traits', {});
-    this.segmentApiCalls = this.store.get('segmentApiCalls', {});
+
+    this.eventStore = new Store<EventsStorage>({
+      name: `mmd-desktop-metrics-events`,
+    });
+
+    this.processedEvents = this.eventStore.get('processedEvents', []);
+
+    this.registerMetricsBridgeHandler();
   }
 
   /* The track method lets you record the actions your users perform. */
   track(event: string, properties: Properties = {}) {
+    const metricsDecision = this.getMetricsDecision();
+    if (metricsDecision === MetricsDecision.DISABLED) {
+      return;
+    }
+
     if (!this.desktopMetricsId) {
       this.setDesktopMetricsId(uuid());
     }
@@ -55,33 +70,42 @@ class MetricsService {
     const eventToTrack = {
       event,
       userId: this.desktopMetricsId,
-      properties: { ...properties, ...this.traits },
+      properties: {
+        ...properties,
+        firstTimeEvent: !this.processedEvents.includes(event),
+        ...this.traits,
+      },
       context: this.buildContext(),
       messageId: uuid(),
     };
 
+    this.saveProcessedEvents(eventToTrack.event);
+
     log.debug('track event', eventToTrack);
 
-    const metricsDecision = this.getMetricsDecision();
-    if (metricsDecision === MetricsDecision.DISABLED) {
-      return;
-    } else if (metricsDecision === MetricsDecision.PENDING) {
+    if (metricsDecision === MetricsDecision.PENDING) {
       this.eventsSavedBeforeMetricsDecision.push(eventToTrack);
+      this.store.set(
+        'eventsSavedBeforeMetricsDecision',
+        this.eventsSavedBeforeMetricsDecision,
+      );
       return;
     }
 
     this.analytics.track(eventToTrack);
-    this.saveCallSegmentAPI(eventToTrack);
   }
 
   /* The identify method lets you tie a user to their actions and record
        traits about them. */
   identify(traits: Traits) {
     log.debug('identify event', traits);
+    this.traits = { ...this.traits, ...traits };
+    this.store.set('traits', this.traits);
+
     if (this.getMetricsDecision() === MetricsDecision.DISABLED) {
       return;
     }
-    this.traits = { ...this.traits, ...traits };
+
     this.analytics.identify({
       userId: this.desktopMetricsId,
       traits: this.traits,
@@ -95,44 +119,30 @@ class MetricsService {
   }
 
   private getMetricsDecision(): MetricsDecision {
+    const defaultValue = undefined;
     const desktopMetricsOptIn = readPersistedSettingFromAppState({
-      defaultValue: undefined,
+      defaultValue,
       key: 'metametricsOptIn',
     });
 
-    if (desktopMetricsOptIn) {
-      // Flush events saved before user opt-in
-      if (this.eventsSavedBeforeMetricsDecision?.length > 0) {
-        this.sendPendingEvents();
-      }
-      return MetricsDecision.ENABLED;
-    } else if (desktopMetricsOptIn === false) {
-      if (this.eventsSavedBeforeMetricsDecision?.length > 0) {
-        this.cleanPendingEvents();
-      }
-      return MetricsDecision.DISABLED;
+    if (desktopMetricsOptIn === defaultValue) {
+      return MetricsDecision.PENDING;
     }
-    return MetricsDecision.PENDING;
+    return desktopMetricsOptIn
+      ? MetricsDecision.ENABLED
+      : MetricsDecision.DISABLED;
   }
 
   private sendPendingEvents() {
     log.debug('sending events saved before user optIn');
     this.eventsSavedBeforeMetricsDecision?.forEach((event) => {
       this.analytics.track(event);
-      this.saveCallSegmentAPI(event);
     });
-
-    this.cleanPendingEvents();
   }
 
   private cleanPendingEvents() {
     this.eventsSavedBeforeMetricsDecision = [];
     this.store.set('eventsSavedBeforeMetricsDecision', []);
-  }
-
-  private saveCallSegmentAPI(event: Event) {
-    this.segmentApiCalls[uuid()] = event;
-    this.store.set('segmentApiCalls', this.segmentApiCalls);
   }
 
   // Build the context object to attach to page and track events.
@@ -143,6 +153,38 @@ class MetricsService {
         version: getDesktopVersion(),
       },
     };
+  }
+
+  private saveProcessedEvents(eventName: string) {
+    if (this.processedEvents.includes(eventName)) {
+      return;
+    }
+    this.processedEvents.push(eventName);
+
+    this.eventStore.set('processedEvents', this.processedEvents);
+  }
+
+  private registerMetricsBridgeHandler() {
+    ipcMain.handle(
+      'analytics-track',
+      (_event, eventName: string, properties: Properties) => {
+        this.track(eventName, properties);
+      },
+    );
+
+    ipcMain.handle('analytics-identify', (_event, traits: Traits) => {
+      this.identify(traits);
+    });
+
+    ipcMain.handle(
+      'analytics-pending-events-handler',
+      (_event, metricsDecision: boolean) => {
+        if (metricsDecision) {
+          this.sendPendingEvents();
+        }
+        this.cleanPendingEvents();
+      },
+    );
   }
 }
 

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -102,18 +102,16 @@ class MetricsService {
     this.traits = { ...this.traits, ...traits };
     this.store.set('traits', this.traits);
 
-    if (this.getMetricsDecision() === MetricsDecision.DISABLED) {
-      return;
+    if (this.getMetricsDecision() === MetricsDecision.ENABLED) {
+      this.analytics.identify({
+        userId: this.desktopMetricsId,
+        traits: this.traits,
+        context: this.buildContext(),
+      });
     }
-
-    this.analytics.identify({
-      userId: this.desktopMetricsId,
-      traits: this.traits,
-      context: this.buildContext(),
-    });
   }
 
-  setDesktopMetricsId(id: string) {
+  private setDesktopMetricsId(id: string) {
     this.desktopMetricsId = id;
     this.store.set('desktopMetricsId', id);
   }

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -10,6 +10,7 @@ import {
   Traits,
   Event,
 } from '../types/metrics';
+import { readPersistedSettingFromAppState } from '../storage/ui-storage';
 import Analytics from './analytics';
 
 class MetricsService {
@@ -17,9 +18,7 @@ class MetricsService {
 
   private analytics: typeof Analytics;
 
-  // TODO: Update participateInDesktopMetrics when user opt-in/opt-out on metrics UI
-  private participateInDesktopMetrics = true;
-
+  // Unique identifier representing userId property on events
   private desktopMetricsId?: string;
 
   // Events saved before users opt-in/opt-out of metrics
@@ -37,10 +36,6 @@ class MetricsService {
       name: `mmd-desktop-metrics`,
     });
 
-    this.participateInDesktopMetrics = this.store.get(
-      'participateInDesktopMetrics',
-      true,
-    );
     this.desktopMetricsId = this.store.get('desktopMetricsId', '');
     this.eventsBeforeMetricsOptIn = this.store.get(
       'eventsBeforeMetricsOptIn',
@@ -52,6 +47,7 @@ class MetricsService {
 
   /* The track method lets you record the actions your users perform. */
   track(event: string, properties: Properties = {}) {
+    log.debug('track event', event);
     if (!this.desktopMetricsId) {
       this.setDesktopMetricsId(uuid());
     }
@@ -64,7 +60,12 @@ class MetricsService {
       messageId: uuid(),
     };
 
-    if (!this.participateInDesktopMetrics) {
+    const isParticipateInDesktopMetrics =
+      this.checkParticipateInDesktopMetrics();
+    if (isParticipateInDesktopMetrics === false) {
+      return;
+      // If the condition is true, it means that the user has not yet opt-in/opt-out on the metrics page
+    } else if (isParticipateInDesktopMetrics === undefined) {
       this.eventsBeforeMetricsOptIn.push(eventToTrack);
       return;
     }
@@ -76,6 +77,10 @@ class MetricsService {
   /* The identify method lets you tie a user to their actions and record
        traits about them. */
   identify(traits: Traits) {
+    log.debug('identify event', traits);
+    if (this.checkParticipateInDesktopMetrics() === false) {
+      return;
+    }
     this.traits = { ...this.traits, ...traits };
     this.analytics.identify({
       userId: this.desktopMetricsId,
@@ -84,26 +89,39 @@ class MetricsService {
     });
   }
 
-  setParticipateInDesktopMetrics(isParticipant: boolean) {
-    this.participateInDesktopMetrics = isParticipant;
-    this.store.set('participateInDesktopMetrics', isParticipant);
-
-    if (isParticipant) {
-      this.flushEventsBeforeOptIn();
-    }
-  }
-
   setDesktopMetricsId(id: string) {
     this.desktopMetricsId = id;
     this.store.set('desktopMetricsId', id);
   }
 
-  // TODO: Implement flush events that are saved before users opt-in/opt-out
-  flushEventsBeforeOptIn() {
-    log.debug('No implementation provided');
+  private checkParticipateInDesktopMetrics(): boolean | undefined {
+    const desktopMetricsOptInValue = readPersistedSettingFromAppState({
+      defaultValue: undefined,
+      key: 'metametricsOptIn',
+    });
+    const desktopMetricsOptIn =
+      typeof desktopMetricsOptInValue === 'string'
+        ? desktopMetricsOptInValue === 'true'
+        : desktopMetricsOptInValue;
+
+    // Flush events saved before user opt-in
+    if (desktopMetricsOptIn && this.eventsBeforeMetricsOptIn?.length > 0) {
+      this.flushEventsBeforeOptIn();
+    }
+    return desktopMetricsOptIn;
   }
 
-  saveCallSegmentAPI(event: Event) {
+  private flushEventsBeforeOptIn() {
+    log.debug('flushing events saved before user optIn');
+    this.eventsBeforeMetricsOptIn?.forEach((event) => {
+      this.analytics.track(event);
+      this.saveCallSegmentAPI(event);
+    });
+
+    this.eventsBeforeMetricsOptIn = [];
+  }
+
+  private saveCallSegmentAPI(event: Event) {
     this.segmentApiCalls[uuid()] = event;
     this.store.set('segmentApiCalls', this.segmentApiCalls);
   }

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -7,6 +7,10 @@ export interface Traits {
   [key: string]: any;
 }
 
+export interface EventsStorage {
+  processedEvents: string[];
+}
+
 export interface Properties {
   paired?: boolean;
   createdAt?: Date;
@@ -21,14 +25,8 @@ export interface Event {
   messageId?: string;
 }
 
-export interface SegmentApiCalls {
-  [key: string]: Event;
-}
-
-export interface MetricsState {
-  participateInDesktopMetrics: boolean;
+export interface MetricsStorage {
   desktopMetricsId?: string;
   eventsSavedBeforeMetricsDecision: Event[];
   traits: Traits;
-  segmentApiCalls: SegmentApiCalls;
 }

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -28,7 +28,7 @@ export interface SegmentApiCalls {
 export interface MetricsState {
   participateInDesktopMetrics: boolean;
   desktopMetricsId?: string;
-  eventsBeforeMetricsOptIn: Event[];
+  eventsSavedBeforeMetricsDecision: Event[];
   traits: Traits;
   segmentApiCalls: SegmentApiCalls;
 }

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Properties } from '../../types/metrics';
+import { Properties } from '../types/metrics';
 
 const uiStoreBridge = (name: string) => {
   return {

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Properties } from '../types/metrics';
+import { Properties, Traits } from '../types/metrics';
 
 const uiStoreBridge = (name: string) => {
   return {
@@ -11,14 +11,6 @@ const uiStoreBridge = (name: string) => {
     },
     removeItem: async (key: string) => {
       await ipcRenderer.invoke(`${name}-store-delete`, key);
-    },
-  };
-};
-
-const analyticsBridge = (name: string) => {
-  return {
-    track: (eventName: string, properties: Properties) => {
-      return ipcRenderer.invoke(`${name}-track`, eventName, properties);
     },
   };
 };
@@ -68,7 +60,18 @@ const electronBridge = {
   setLanguage: async (language: string) => {
     await ipcRenderer.invoke('set-language', language);
   },
-  analytics: analyticsBridge('analytics'),
+  track: (eventName: string, properties: Properties) => {
+    return ipcRenderer.invoke('analytics-track', eventName, properties);
+  },
+  identify: (traits: Traits) => {
+    return ipcRenderer.invoke('analytics-identify', traits);
+  },
+  analyticsPendingEventsHandler: (metricsDecision: boolean) => {
+    return ipcRenderer.invoke(
+      'analytics-pending-events-handler',
+      metricsDecision,
+    );
+  },
 };
 
 contextBridge.exposeInMainWorld('electronBridge', electronBridge);

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import { Properties } from '../../types/metrics';
 
 const uiStoreBridge = (name: string) => {
   return {
@@ -10,6 +11,14 @@ const uiStoreBridge = (name: string) => {
     },
     removeItem: async (key: string) => {
       await ipcRenderer.invoke(`${name}-store-delete`, key);
+    },
+  };
+};
+
+const analyticsBridge = (name: string) => {
+  return {
+    track: (eventName: string, properties: Properties) => {
+      return ipcRenderer.invoke(`${name}-track`, eventName, properties);
     },
   };
 };
@@ -59,6 +68,7 @@ const electronBridge = {
   setLanguage: async (language: string) => {
     await ipcRenderer.invoke('set-language', language);
   },
+  analytics: analyticsBridge('analytics'),
 };
 
 contextBridge.exposeInMainWorld('electronBridge', electronBridge);

--- a/packages/app/src/ui/components/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/packages/app/src/ui/components/metametrics-opt-in/metametrics-opt-in.component.js
@@ -96,6 +96,7 @@ const MetaMetricsOptIn = ({ updateMetametricsOptIn }) => {
           <Button
             type="secondary"
             onClick={() => {
+              window.electronBridge.analyticsPendingEventsHandler(false);
               updateMetametricsOptIn(false);
               history.push(PAIR_ROUTE);
             }}
@@ -105,6 +106,7 @@ const MetaMetricsOptIn = ({ updateMetametricsOptIn }) => {
           <Button
             type="primary"
             onClick={() => {
+              window.electronBridge.analyticsPendingEventsHandler(true);
               updateMetametricsOptIn(true);
               history.push(PAIR_ROUTE);
             }}

--- a/packages/app/src/ui/pages/index.js
+++ b/packages/app/src/ui/pages/index.js
@@ -5,6 +5,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import PropTypes from 'prop-types';
 
 import { I18nProvider } from '../contexts/i18n';
+import { EVENT_NAMES } from '../../app/metrics/metrics-constants';
 import Routes from './routes';
 import CriticalError from './error/critical-error.component';
 
@@ -17,6 +18,7 @@ class Root extends PureComponent {
 
   componentDidCatch(error) {
     // TODO: Sentry.captureException(error);
+    window.electronBridge.track(EVENT_NAMES.UI_CRITICAL_ERROR);
     console.error('Exception Error Page', error);
   }
 

--- a/packages/app/src/ui/pages/pair/pair.component.js
+++ b/packages/app/src/ui/pages/pair/pair.component.js
@@ -20,8 +20,6 @@ import {
 import Mascot from '../../components/mascot';
 import Spinner from '../../../../submodules/extension/ui/components/ui/spinner';
 import { URL_SUBMIT_TICKET } from '../../../shared/constants/links';
-// eslint-disable-next-line import/no-unresolved
-import { EVENT_NAMES } from '../../../app/metrics/metrics-constants';
 
 const ANIMATION_COMPLETE_DEFER_IN_MS = 1000;
 const OTP_VALIDATION_TIMEOUT_IN_MS = 5000;
@@ -77,10 +75,6 @@ const Pair = ({ isDesktopPaired, isSuccessfulPairSeen, history }) => {
         setOtpTimeoutError(true);
         setOtpValidating(false);
         setOtpDisabled(false);
-        window.electronBridge.analytics.track(EVENT_NAMES.INVALID_OTP, {
-          paired: false,
-          error: 'Timeout: no response when validating',
-        });
       }, OTP_VALIDATION_TIMEOUT_IN_MS + ANIMATION_COMPLETE_DEFER_IN_MS);
       setOtpValidationTimeoutId(timeoutId);
     }

--- a/packages/app/src/ui/pages/pair/pair.component.js
+++ b/packages/app/src/ui/pages/pair/pair.component.js
@@ -21,7 +21,7 @@ import Mascot from '../../components/mascot';
 import Spinner from '../../../../submodules/extension/ui/components/ui/spinner';
 import { URL_SUBMIT_TICKET } from '../../../shared/constants/links';
 // eslint-disable-next-line import/no-unresolved
-import { EVENT_NAMES } from '../../../src/app/metrics/metrics-constants';
+import { EVENT_NAMES } from '../../../app/metrics/metrics-constants';
 
 const ANIMATION_COMPLETE_DEFER_IN_MS = 1000;
 const OTP_VALIDATION_TIMEOUT_IN_MS = 5000;

--- a/packages/app/src/ui/pages/pair/pair.component.js
+++ b/packages/app/src/ui/pages/pair/pair.component.js
@@ -20,6 +20,8 @@ import {
 import Mascot from '../../components/mascot';
 import Spinner from '../../../../submodules/extension/ui/components/ui/spinner';
 import { URL_SUBMIT_TICKET } from '../../../shared/constants/links';
+// eslint-disable-next-line import/no-unresolved
+import { EVENT_NAMES } from '../../../src/app/metrics/metrics-constants';
 
 const ANIMATION_COMPLETE_DEFER_IN_MS = 1000;
 const OTP_VALIDATION_TIMEOUT_IN_MS = 5000;
@@ -75,12 +77,16 @@ const Pair = ({ isDesktopPaired, isSuccessfulPairSeen, history }) => {
         setOtpTimeoutError(true);
         setOtpValidating(false);
         setOtpDisabled(false);
+        window.electronBridge.analytics.track(EVENT_NAMES.INVALID_OTP, {
+          paired: false,
+          error: 'Timeout: no response when validating',
+        });
       }, OTP_VALIDATION_TIMEOUT_IN_MS + ANIMATION_COMPLETE_DEFER_IN_MS);
       setOtpValidationTimeoutId(timeoutId);
     }
   };
 
-  const handleOnSettinsIconClick = () => {
+  const handleOnSettingsIconClick = () => {
     history.push(SETTINGS_ROUTE);
   };
 
@@ -88,7 +94,7 @@ const Pair = ({ isDesktopPaired, isSuccessfulPairSeen, history }) => {
     <>
       <div
         className="mmd-pair-page__settings-icon"
-        onClick={handleOnSettinsIconClick}
+        onClick={handleOnSettingsIconClick}
       >
         <SettingIcon width="24" height="24" fill="var(--color-text-muted)" />
       </div>

--- a/packages/app/src/ui/pages/routes/routes.component.js
+++ b/packages/app/src/ui/pages/routes/routes.component.js
@@ -16,6 +16,7 @@ import Settings from '../settings';
 import ErrorPage from '../error';
 import MetametricsOptInPage from '../metametrics-opt-in';
 import useDeeplinkRegister from '../../hooks/useDeeplinkRegister';
+import { EVENT_NAMES } from '../../../app/metrics/metrics-constants';
 
 const Routes = ({ theme }) => {
   useDeeplinkRegister();
@@ -23,6 +24,10 @@ const Routes = ({ theme }) => {
     // Set theme (html attr) for the first time
     setTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    window.electronBridge.track(EVENT_NAMES.DESKTOP_UI_LOADED);
+  }, []);
 
   return (
     <div id="mmd-app-content">


### PR DESCRIPTION
## Overview
The aim of this PR is to implement a method to flush events saved before users opt-in/opt-out and as a prerequisite of this ticket a mechanism to get the option chosen by the users on the metrics page.

## Changes
- Exposed `track` method on the electron bridge and handle it in the main process.
- Removed `participateInDesktopMetrics` in `metrics-service.ts` and used `readPersistedSettingFromAppState` to get `metametricsOptIn`.
-  create `sendPendingEvents()` to send events saved before the user opt-in.
- added event whenever the user submits OTP and an error is triggered because of timeout.


## Others


## Issues
resolves: #455 and #464