### PR TITLE
chore: metrics infrastructure for first-time events

### DIFF
--- a/packages/app/src/app/controller-init.test.ts
+++ b/packages/app/src/app/controller-init.test.ts
@@ -4,6 +4,16 @@ import { AppDesktopController } from './controller-init';
 
 jest.mock('./desktop-app');
 
+jest.mock(
+  'electron',
+  () => ({
+    ipcMain: { handle: jest.fn() },
+  }),
+  {
+    virtual: true,
+  },
+);
+
 describe('App Desktop Controller', () => {
   const desktopAppMock = desktopApp as jest.Mocked<typeof desktopApp>;
   const extensionConnectionMock = createExtensionConnectionMock();

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -19,7 +19,6 @@ import { forwardEvents } from './utils/events';
 import { determineLoginItemSettings } from './utils/settings';
 import cfg from './utils/config';
 import { getDesktopVersion } from './utils/version';
-import { Properties } from './types/metrics';
 import ExtensionConnection from './extension-connection';
 import { updateCheck } from './update-check';
 import {
@@ -127,13 +126,6 @@ class DesktopApp extends EventEmitter {
     ipcMain.handle('open-external', (_event, link) => {
       shell.openExternal(link);
     });
-
-    ipcMain.handle(
-      'analytics-track',
-      (_event, eventName: string, properties: Properties) => {
-        this.metricsService.track(eventName, properties);
-      },
-    );
 
     if (!cfg().ui.preventOpenOnStartup) {
       ipcMain.handle('set-preferred-startup', (_event, preferredStartup) => {

--- a/packages/app/src/app/main.ts
+++ b/packages/app/src/app/main.ts
@@ -13,12 +13,14 @@ import { LedgerBridgeKeyring as LedgerKeyring } from './hw/ledger/ledger-keyring
 import TrezorKeyring from './hw/trezor/trezor-keyring';
 import LatticeKeyring from './hw/lattice/lattice-keyring';
 import DesktopApp from './desktop-app';
+import metricsService from './metrics/metrics-service';
+import { EVENT_NAMES } from './metrics/metrics-constants';
 
 /**
  * TODO
  * Gets user the preferred language code.
  *
- * @returns The laguange code to be used for the app localisation. Defaults to 'en'.
+ * @returns The language code to be used for the app localisation. Defaults to 'en'.
  */
 const getFirstPreferredLangCode = () => {
   return 'en';
@@ -109,6 +111,7 @@ const onDesktopRestart = async (desktopApp: typeof DesktopApp) => {
  * Initialize desktop app.
  */
 const initDesktopApp = async () => {
+  metricsService.track(EVENT_NAMES.DESKTOP_APP_STARTING);
   await DesktopApp.init();
   DesktopApp.on('restart', () => onDesktopRestart(DesktopApp));
 };

--- a/packages/app/src/app/metrics/analytics.test.ts
+++ b/packages/app/src/app/metrics/analytics.test.ts
@@ -40,4 +40,31 @@ describe('Analytics', () => {
       ...message,
     });
   });
+
+  it('calls page on the analytics-node instance', () => {
+    const spy = jest.spyOn(analytics, 'page');
+    const message = {
+      name: EVENT_NAME_MOCK,
+      userId: UUID_MOCK,
+      properties: PROPERTIES_OBJECT_MOCK,
+      messageId: UUID_MOCK,
+    };
+    analytics.page(message);
+    expect(spy).toHaveBeenCalledWith({
+      ...message,
+    });
+  });
+
+  it('calls screen on the analytics-node instance', () => {
+    const spy = jest.spyOn(analytics, 'screen');
+    const message = {
+      name: EVENT_NAME_MOCK,
+      userId: UUID_MOCK,
+      properties: PROPERTIES_OBJECT_MOCK,
+    };
+    analytics.screen(message);
+    expect(spy).toHaveBeenCalledWith({
+      ...message,
+    });
+  });
 });

--- a/packages/app/src/app/metrics/analytics.ts
+++ b/packages/app/src/app/metrics/analytics.ts
@@ -16,7 +16,10 @@ class Analytics {
       context?: any;
     },
   ): void {
-    Analytics.instance.identify({ ...message, timestamp: new Date() });
+    Analytics.instance.identify({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
   }
 
   public track(
@@ -27,7 +30,40 @@ class Analytics {
       context?: any;
     },
   ): void {
-    Analytics.instance.track({ ...message, timestamp: new Date() });
+    Analytics.instance.track({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
+  }
+
+  public page(
+    message: Identity & {
+      category?: string | undefined;
+      name?: string | undefined;
+      properties?: any;
+      timestamp?: Date | undefined;
+      context?: any;
+      messageId?: string | undefined;
+    },
+  ): void {
+    Analytics.instance.page({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
+  }
+
+  public screen(
+    message: Identity & {
+      name?: string | undefined;
+      properties?: any;
+      timestamp?: Date | undefined;
+      context?: any;
+    },
+  ): void {
+    Analytics.instance.screen({
+      ...message,
+      timestamp: message.timestamp || new Date(),
+    });
   }
 
   private init = () => {

--- a/packages/app/src/app/metrics/metrics-constants.ts
+++ b/packages/app/src/app/metrics/metrics-constants.ts
@@ -6,6 +6,9 @@ export const EVENT_NAMES = {
   METRICS_OPT_IN: 'Metrics Opt In',
   METRICS_OPT_OUT: 'Metrics Opt Out',
   INVALID_OTP: 'Invalid OTP',
+  DESKTOP_APP_STARTING: 'Desktop App Starting',
+  DESKTOP_UI_LOADED: 'Desktop UI Loaded',
+  UI_CRITICAL_ERROR: 'Desktop UI Critical Error',
 };
 
 export enum MetricsDecision {

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -52,6 +52,7 @@ jest.mock(
   'electron',
   () => ({
     app: { name: jest.fn() },
+    ipcMain: { handle: jest.fn() },
   }),
   {
     virtual: true,

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -33,6 +33,8 @@ jest.mock(
               return {};
             case 'eventsSavedBeforeMetricsDecision':
               return [];
+            case 'firstTimeEvents':
+              return { 'mock-event-name': true, 'mock-event-name-2': true };
             default:
               return undefined;
           }

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -34,7 +34,7 @@ jest.mock(
             case 'eventsSavedBeforeMetricsDecision':
               return [];
             case 'firstTimeEvents':
-              return { 'mock-event-name': true, 'mock-event-name-2': true };
+              return new Set<string>(['mock-event-name', 'mock-event-name-2']);
             default:
               return undefined;
           }
@@ -87,9 +87,9 @@ describe('MetricsService', () => {
     jest.clearAllMocks();
   });
 
-  it('set desktopMetricsId', () => {
+  it('sets desktop metrics id', () => {
     metricsService.setDesktopMetricsId(UUID_MOCK);
-    expect(electronStoreConstructorMock).toHaveBeenCalledTimes(1);
+    expect(electronStoreConstructorMock).toHaveBeenCalledTimes(2);
   });
 
   it('tracks an event with properties and saved it to the store', () => {

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -29,8 +29,6 @@ jest.mock(
           switch (value) {
             case 'participateInDesktopMetrics':
               return true;
-            case 'segmentApiCalls':
-              return {};
             case 'eventsSavedBeforeMetricsDecision':
               return [];
             case 'firstTimeEvents':

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -34,7 +34,7 @@ jest.mock(
             case 'eventsSavedBeforeMetricsDecision':
               return [];
             case 'firstTimeEvents':
-              return new Set<string>(['mock-event-name', 'mock-event-name-2']);
+              return ['mock-event-name-2'];
             default:
               return undefined;
           }
@@ -92,20 +92,30 @@ describe('MetricsService', () => {
     expect(electronStoreConstructorMock).toHaveBeenCalledTimes(2);
   });
 
-  it('tracks an event with properties and saved it to the store', () => {
-    metricsService.track(EVENT_NAME_MOCK, PROPERTIES_OBJECT_MOCK);
+  describe('track events', () => {
+    it.each([true, false])(
+      `tracks an event with the property firstTimeEvent $firstTimeEvent and saved it to the store`,
+      (firstTimeEvent) => {
+        getMetricsDecisionSpy.mockReturnValue(MetricsDecision.ENABLED);
+        metricsService.track(EVENT_NAME_MOCK, PROPERTIES_OBJECT_MOCK);
 
-    expect(trackSpy).toHaveBeenCalledTimes(1);
-    expect(analytics.track).toHaveBeenCalledWith({
-      event: EVENT_NAME_MOCK,
-      userId: expect.any(String),
-      properties: PROPERTIES_OBJECT_MOCK,
-      context: expect.any(Object),
-      messageId: expect.any(String),
-    });
+        expect(trackSpy).toHaveBeenCalledTimes(1);
+        expect(analytics.track).toHaveBeenCalledWith({
+          event: EVENT_NAME_MOCK,
+          userId: expect.any(String),
+          properties: {
+            ...PROPERTIES_OBJECT_MOCK,
+            firstTimeEvent,
+          },
+          context: expect.any(Object),
+          messageId: expect.any(String),
+        });
+      },
+    );
   });
 
   it('tracks an event before users opted in and store it in eventsSavedBeforeMetricsDecision', () => {
+    getMetricsDecisionSpy.mockReturnValue(MetricsDecision.PENDING);
     metricsService.track(EVENT_NAME_MOCK, PROPERTIES_OBJECT_MOCK);
 
     expect(trackSpy).toHaveBeenCalledTimes(0);

--- a/packages/app/src/app/metrics/metrics-service.test.ts
+++ b/packages/app/src/app/metrics/metrics-service.test.ts
@@ -31,7 +31,7 @@ jest.mock(
               return true;
             case 'eventsSavedBeforeMetricsDecision':
               return [];
-            case 'firstTimeEvents':
+            case 'processedEvents':
               return ['mock-event-name-2'];
             default:
               return undefined;

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -6,7 +6,6 @@ import { getDesktopVersion } from '../utils/version';
 import {
   MetricsStorage,
   Properties,
-  SegmentApiCalls,
   Traits,
   Event,
   EventsStorage,
@@ -31,9 +30,6 @@ class MetricsService {
   // Traits are pieces of information you know about a user that are included in an identify call
   private traits: Traits;
 
-  // Every event submitted to segment
-  private segmentApiCalls: SegmentApiCalls;
-
   // Tracks first time events
   private firstTimeEvents: string[];
 
@@ -50,7 +46,6 @@ class MetricsService {
       [],
     );
     this.traits = this.store.get('traits', {});
-    this.segmentApiCalls = this.store.get('segmentApiCalls', {});
 
     this.eventStore = new Store<EventsStorage>({
       name: `mmd-desktop-metrics-events`,
@@ -96,7 +91,6 @@ class MetricsService {
     }
 
     this.analytics.track(eventToTrack);
-    this.saveCallSegmentAPI(eventToTrack);
   }
 
   /* The identify method lets you tie a user to their actions and record
@@ -144,7 +138,6 @@ class MetricsService {
     log.debug('sending events saved before user optIn');
     this.eventsSavedBeforeMetricsDecision?.forEach((event) => {
       this.analytics.track(event);
-      this.saveCallSegmentAPI(event);
     });
 
     this.cleanPendingEvents();
@@ -153,11 +146,6 @@ class MetricsService {
   private cleanPendingEvents() {
     this.eventsSavedBeforeMetricsDecision = [];
     this.store.set('eventsSavedBeforeMetricsDecision', []);
-  }
-
-  private saveCallSegmentAPI(event: Event) {
-    this.segmentApiCalls[uuid()] = event;
-    this.store.set('segmentApiCalls', this.segmentApiCalls);
   }
 
   // Build the context object to attach to page and track events.

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -32,6 +32,7 @@ class MetricsService {
   // Every event submitted to segment
   private segmentApiCalls: SegmentApiCalls;
 
+  // Tracks first time events
   private firstTimeEvents: FirstTimeEvents;
 
   constructor() {
@@ -40,7 +41,7 @@ class MetricsService {
       name: `mmd-desktop-metrics`,
     });
 
-    // Creates an object with the events and set the value first time event to true
+    // Creates an object with all events and sets the value first-time event to true
     const defaultFirstTimeEvents: FirstTimeEvents = {};
     for (const event of Object.values(EVENT_NAMES)) {
       defaultFirstTimeEvents[event] = true;
@@ -87,15 +88,6 @@ class MetricsService {
 
     this.analytics.track(eventToTrack);
     this.saveCallSegmentAPI(eventToTrack);
-  }
-
-  private checkAndUpdateFirstTimeEvent(eventName: string) {
-    if (!this.firstTimeEvents[eventName]) {
-      return;
-    }
-    this.firstTimeEvents[eventName] = false;
-
-    this.store.set('firstTimeEvents', this.firstTimeEvents);
   }
 
   /* The identify method lets you tie a user to their actions and record
@@ -167,6 +159,15 @@ class MetricsService {
         version: getDesktopVersion(),
       },
     };
+  }
+
+  private checkAndUpdateFirstTimeEvent(eventName: string) {
+    if (!this.firstTimeEvents[eventName]) {
+      return;
+    }
+    this.firstTimeEvents[eventName] = false;
+
+    this.store.set('firstTimeEvents', this.firstTimeEvents);
   }
 }
 

--- a/packages/app/src/app/metrics/metrics-service.ts
+++ b/packages/app/src/app/metrics/metrics-service.ts
@@ -9,6 +9,7 @@ import {
   SegmentApiCalls,
   Traits,
   Event,
+  FirstTimeEvents,
 } from '../types/metrics';
 import { readPersistedSettingFromAppState } from '../storage/ui-storage';
 import Analytics from './analytics';
@@ -30,6 +31,8 @@ class MetricsService {
 
   // Every event submitted to segment
   private segmentApiCalls: SegmentApiCalls;
+
+  private firstTimeEvents: FirstTimeEvents;
 
   constructor() {
     this.analytics = Analytics;
@@ -72,6 +75,25 @@ class MetricsService {
 
     this.analytics.track(eventToTrack);
     this.saveCallSegmentAPI(eventToTrack);
+
+    this.checkFirstTimeEvent(eventToTrack.event);
+  }
+
+  private checkFirstTimeEvent(eventName: string): boolean {
+    const isFirstTimeEvent = this.firstTimeEvents[eventName];
+    if (!isFirstTimeEvent) {
+      // false
+      return isFirstTimeEvent;
+    }
+    this.firstTimeEvents[eventName] = false;
+    return true;
+
+    // for (const eventSaved of Object.values(this.saveCallSegmentAPI)) {
+    //   if (eventName === eventSaved.event) {
+    //     return true;
+    //   }
+    // }
+    // return false;
   }
 
   /* The identify method lets you tie a user to their actions and record

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -30,9 +30,9 @@ export interface SegmentApiCalls {
 }
 
 export interface MetricsState {
-  participateInDesktopMetrics: boolean;
   desktopMetricsId?: string;
   eventsSavedBeforeMetricsDecision: Event[];
   traits: Traits;
   segmentApiCalls: SegmentApiCalls;
+  firstTimeEvents: FirstTimeEvents;
 }

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -7,8 +7,8 @@ export interface Traits {
   [key: string]: any;
 }
 
-export interface FirstTimeEvents {
-  [key: string]: boolean;
+export interface EventsStorage {
+  firstTimeEvents: Set<string>;
 }
 
 export interface Properties {
@@ -29,10 +29,9 @@ export interface SegmentApiCalls {
   [key: string]: Event;
 }
 
-export interface MetricsState {
+export interface MetricsStorage {
   desktopMetricsId?: string;
   eventsSavedBeforeMetricsDecision: Event[];
   traits: Traits;
   segmentApiCalls: SegmentApiCalls;
-  firstTimeEvents: FirstTimeEvents;
 }

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -25,13 +25,8 @@ export interface Event {
   messageId?: string;
 }
 
-export interface SegmentApiCalls {
-  [key: string]: Event;
-}
-
 export interface MetricsStorage {
   desktopMetricsId?: string;
   eventsSavedBeforeMetricsDecision: Event[];
   traits: Traits;
-  segmentApiCalls: SegmentApiCalls;
 }

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -8,7 +8,7 @@ export interface Traits {
 }
 
 export interface EventsStorage {
-  firstTimeEvents: string[];
+  processedEvents: string[];
 }
 
 export interface Properties {

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -7,6 +7,10 @@ export interface Traits {
   [key: string]: any;
 }
 
+export interface FirstTimeEvents {
+  [key: string]: boolean;
+}
+
 export interface Properties {
   paired?: boolean;
   createdAt?: Date;

--- a/packages/app/src/app/types/metrics.ts
+++ b/packages/app/src/app/types/metrics.ts
@@ -8,7 +8,7 @@ export interface Traits {
 }
 
 export interface EventsStorage {
-  firstTimeEvents: Set<string>;
+  firstTimeEvents: string[];
 }
 
 export interface Properties {

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -15,17 +15,6 @@ const uiStoreBridge = (name: string) => {
   };
 };
 
-const analyticsBridge = (name: string) => {
-  return {
-    track: (eventName: string, properties: Properties) => {
-      return ipcRenderer.invoke(`${name}-track`, eventName, properties);
-    },
-    identify: (traits: Traits) => {
-      return ipcRenderer.invoke(`${name}-identify`, traits);
-    },
-  };
-};
-
 const electronBridge = {
   appStore: uiStoreBridge('app'),
   pairStatusStore: uiStoreBridge('pair-status'),
@@ -71,7 +60,12 @@ const electronBridge = {
   setLanguage: async (language: string) => {
     await ipcRenderer.invoke('set-language', language);
   },
-  analytics: analyticsBridge('analytics'),
+  track: (eventName: string, properties: Properties) => {
+    return ipcRenderer.invoke('analytics-track', eventName, properties);
+  },
+  identify: (traits: Traits) => {
+    return ipcRenderer.invoke('analytics-identify', traits);
+  },
 };
 
 contextBridge.exposeInMainWorld('electronBridge', electronBridge);

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import { Properties } from '../types/metrics';
+import { Properties, Traits } from '../types/metrics';
 
 const uiStoreBridge = (name: string) => {
   return {
@@ -19,6 +19,9 @@ const analyticsBridge = (name: string) => {
   return {
     track: (eventName: string, properties: Properties) => {
       return ipcRenderer.invoke(`${name}-track`, eventName, properties);
+    },
+    identify: (traits: Traits) => {
+      return ipcRenderer.invoke(`${name}-identify`, traits);
     },
   };
 };

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -66,6 +66,12 @@ const electronBridge = {
   identify: (traits: Traits) => {
     return ipcRenderer.invoke('analytics-identify', traits);
   },
+  analyticsPendingEventsHandler: (metricsDecision: boolean) => {
+    return ipcRenderer.invoke(
+      'analytics-pending-events-handler',
+      metricsDecision,
+    );
+  },
 };
 
 contextBridge.exposeInMainWorld('electronBridge', electronBridge);

--- a/packages/app/src/ui/components/metametrics-opt-in/metametrics-opt-in.component.js
+++ b/packages/app/src/ui/components/metametrics-opt-in/metametrics-opt-in.component.js
@@ -96,6 +96,7 @@ const MetaMetricsOptIn = ({ updateMetametricsOptIn }) => {
           <Button
             type="secondary"
             onClick={() => {
+              window.electronBridge.analyticsPendingEventsHandler(false);
               updateMetametricsOptIn(false);
               history.push(PAIR_ROUTE);
             }}
@@ -105,6 +106,7 @@ const MetaMetricsOptIn = ({ updateMetametricsOptIn }) => {
           <Button
             type="primary"
             onClick={() => {
+              window.electronBridge.analyticsPendingEventsHandler(true);
               updateMetametricsOptIn(true);
               history.push(PAIR_ROUTE);
             }}

--- a/packages/app/src/ui/pages/index.js
+++ b/packages/app/src/ui/pages/index.js
@@ -5,6 +5,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import PropTypes from 'prop-types';
 
 import { I18nProvider } from '../contexts/i18n';
+import { EVENT_NAMES } from '../../app/metrics/metrics-constants';
 import Routes from './routes';
 import CriticalError from './error/critical-error.component';
 
@@ -17,6 +18,7 @@ class Root extends PureComponent {
 
   componentDidCatch(error) {
     // TODO: Sentry.captureException(error);
+    window.electronBridge.track(EVENT_NAMES.UI_CRITICAL_ERROR);
     console.error('Exception Error Page', error);
   }
 

--- a/packages/app/src/ui/pages/routes/routes.component.js
+++ b/packages/app/src/ui/pages/routes/routes.component.js
@@ -16,6 +16,7 @@ import Settings from '../settings';
 import ErrorPage from '../error';
 import MetametricsOptInPage from '../metametrics-opt-in';
 import useDeeplinkRegister from '../../hooks/useDeeplinkRegister';
+import { EVENT_NAMES } from '../../../app/metrics/metrics-constants';
 
 const Routes = ({ theme }) => {
   useDeeplinkRegister();
@@ -23,6 +24,10 @@ const Routes = ({ theme }) => {
     // Set theme (html attr) for the first time
     setTheme(theme);
   }, [theme]);
+
+  useEffect(() => {
+    window.electronBridge.track(EVENT_NAMES.DESKTOP_UI_LOADED);
+  }, []);
 
   return (
     <div id="mmd-app-content">


### PR DESCRIPTION
## Overview
The aim of this PR is to implement the infrastructure for first-time events and send events to the segment whenever the main process is started and also when UI is loaded.

## Changes
- `metrics-service.ts`: created the infrastructure for first-time events.
  -  create a separate electron store to save first-time events.
  - whenever the track method is called it checks if events were already sent before and include a boolean property on the event object. 
- exposed `page` and `screen` methods from segment SDK on the analytics wrapper.
- moved `ipcMain. handlers` to `metrics-service.ts`.
- Track events:
  -  `DESKTOP_APP_STARTING` sending right before `DesktopApp.init()` in the `main.ts`
  - `DESKTOP_UI_LOADED` sending from `routes.component.js`
  - `UI_CRITICAL_ERROR` included an additional event because either routes loaded or `componentDidCatch` in case of an error.

## Issues
resolves: #416 and #481