### PR TITLE
Create additional pipeline for e2e when extension PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,49 @@ parameters:
   extension-dir:
     type: string
     default: packages/app/submodules/extension
+  extension-release:
+    type: boolean
+    default: false    
+  extension-release-branch:
+    type: string
+    default: main
+  app-stable-branch:
+    type: string
+    default: main
 
 commands:
   checkout_with_submodule:
     steps:
-      - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "aa:9c:7b:e9:01:de:82:e6:d4:ae:5e:ff:c3:fa:d9:5c"
-      - run:
-          name: Setup submodule
-          command: sh scripts/init-submodule.sh
+      - when:
+          condition:
+            and: # All must be true to trigger
+            - equal: [false, << pipeline.parameters.extension-release >>]
+          steps:
+          - checkout
+          - add_ssh_keys:
+              fingerprints:
+                - "aa:9c:7b:e9:01:de:82:e6:d4:ae:5e:ff:c3:fa:d9:5c"
+          - run:
+              name: Setup submodule
+              command: sh scripts/init-submodule.sh
+      - when:
+          condition:
+            and: # All must be true to trigger
+            - equal: [true, << pipeline.parameters.extension-release >>]
+          steps:
+          - run: 
+              name: checkout
+              command: git clone -b "<< pipeline.parameters.app-stable-branch >>" "https://github.com/MetaMask/metamask-desktop.git" .
+          - add_ssh_keys:
+              fingerprints:
+                - "aa:9c:7b:e9:01:de:82:e6:d4:ae:5e:ff:c3:fa:d9:5c"            
+          - run:
+              name: Setup submodule
+              command: | 
+                ssh-keyscan github.com >> ~/.ssh/known_hosts
+                sh scripts/init-submodule.sh
+                cd packages/app/submodules/extension
+                git checkout << pipeline.parameters.extension-release-branch >>   
 
 executors:
   node-browsers:
@@ -56,6 +88,9 @@ executors:
 
 workflows:
   test_and_release:
+    when:
+      and: # All must be true to trigger
+      - equal: [false, << pipeline.parameters.extension-release >>]  
     jobs:
       - install-deps
       - install-deps-extension:
@@ -150,6 +185,65 @@ workflows:
           requires:
             - build-app
             - build-ui
+
+  released_extension_test:
+    when:
+      and: # All must be true to trigger
+      - equal: [true, << pipeline.parameters.extension-release >>]
+
+    jobs:
+      - install-deps
+      - install-deps-extension:
+          requires:
+            - build-common
+      - validate-deps:
+          requires:
+            - install-deps
+      - validate-lock-duplicates:
+          requires:
+            - install-deps
+      - validate-lavamoat-config:
+          requires:
+            - install-deps-extension
+      - audit:
+          requires:
+            - install-deps
+      - build-common:
+          requires:
+            - install-deps
+      - build-app-test-extension:
+          requires:
+            - install-deps-extension
+      - build-app-test-app:
+          requires:
+            - install-deps-extension
+      - build-ui-test-extension:
+          requires:
+            - install-deps-extension
+      - build-ui-test-app:
+          requires:
+            - install-deps-extension
+      - build-extension-test-extension:
+          requires:
+            - install-deps-extension
+      - build-extension-test-app:
+          requires:
+            - install-deps-extension
+      - test-e2e-extension:
+          requires:
+            - build-app-test-extension
+            - build-ui-test-extension
+            - build-extension-test-extension
+      - test-e2e-extension-snaps:
+          requires:
+            - build-app-test-extension
+            - build-ui-test-extension
+            - build-extension-test-extension
+      - test-e2e-app:
+          requires:
+            - build-app-test-app
+            - build-ui-test-app
+            - build-extension-test-app
 
 jobs:
   install-deps:

--- a/packages/app/lavamoat/node/policy-override.json
+++ b/packages/app/lavamoat/node/policy-override.json
@@ -247,6 +247,9 @@
     "@metamask/eth-ledger-bridge-keyring>ethereumjs-util>ethereum-cryptography>secp256k1": {
       "native": true
     },
+    "@metamask/eth-ledger-bridge-keyring>eth-sig-util>ethereumjs-util>ethereum-cryptography>secp256k1": {
+      "native": true
+    },
     "@metamask/gas-fee-controller>ethereumjs-util>ethereum-cryptography>keccak": {
       "native": true
     },
@@ -333,6 +336,9 @@
         "hdkey>safe-buffer": true,
         "eth-sig-util>ethereumjs-util>safe-buffer": true
       }
+    },
+    "eth-sig-util>ethereumjs-util>ethereum-cryptography>secp256k1": {
+      "native": true
     },
     "eth-trezor-keyring>@ethereumjs/tx>@ethereumjs/common>ethereumjs-util>ethereum-cryptography>keccak": {
       "native": true


### PR DESCRIPTION
# Overview

<!-- Summarise the purpose of the pull request or the problem that is being addressed: -->
implements desktop part of [Create an additional pipeline to run e2e tests with desktop app enabled](https://github.com/MetaMask/metamask-desktop/issues/149)

The request required to trigger the pipeline from extension should be:
curl --location --request POST 'https://circleci.com/api/v2/project/gh/MetaMask/metamask-desktop/pipeline' \
--header 'Content-Type: application/json' \
--header 'Circle-Token: *****' \
--header 'Authorization: Basic *****' \
--data-raw '{"branch":"app-stable","parameters":{"extension-release":true, "extension-release-branch": "<<extension-release-branch>>"}}'

<<extension-release-branch>> is the release branch that desktop will be pulling from MM.

# Changes

## Root

<!-- List of changes to the root directory: -->

## Pipeline

<!-- List of changes to the GitHub or CircleCI pipelines: -->

## Common

<!-- List of changes to the common workspace containing the @metamask/desktop package: -->

## App

<!-- List of changes to the app workspace containing the Electron application: -->
