### PR TITLE
fix: common build workflow after yarn 3 update

### DIFF
--- a/.github/workflows/publish-common-release.yml
+++ b/.github/workflows/publish-common-release.yml
@@ -12,7 +12,7 @@ on:
   push:
     paths:
       - packages/common/**
-    branches: [main-desktop]
+    branches: [main]
 
 jobs:
   check-common-workflows:
@@ -38,7 +38,7 @@ jobs:
         if:  ${{ !github.event.inputs.bypass_is_release }}
         uses: MetaMask/action-is-release@v1
         with:
-          commit-starts-with: 'Release [version]'
+          commit-starts-with: 'Release Common [version]'
 
   build:
     needs: is-release
@@ -55,10 +55,9 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install
         shell: bash
-        run: |
-          yarn common install --immutable
-          yarn common build
+        run: yarn install --immutable
       - name: Build
+        shell: bash
         run: yarn common build
       - uses: actions/cache@v3
         id: restore-build


### PR DESCRIPTION
# Overview

Fixes the common package build workflow. After yarn 3 upgrade we cannot do `yarn common install` straight away. We need to run yarn first in the root of the repo.

# Changes

## Root

None

## Pipeline

* Update publish-common-release.yml workflow

## Common

None

## App

None
