### PR TITLE
fix: add z-index value to draggable bar

### DIFF
--- a/packages/app/src/ui/css/index.scss
+++ b/packages/app/src/ui/css/index.scss
@@ -44,6 +44,7 @@ body {
   position: fixed;
   top: 0;
   background-color: var(--color-background-default);
+  z-index: 1;
 }
 
 @import '../pages/mmd-pages.scss';


### PR DESCRIPTION
# Overview 
This PR aims to fix draggable top bar overlay issue.
Before:
![Screenshot 2023-02-07 at 19 28 21](https://user-images.githubusercontent.com/7644512/217333773-1c21d038-8570-47a6-9e0f-1379063e5537.png)
After: 
![Screenshot 2023-02-07 at 19 28 24](https://user-images.githubusercontent.com/7644512/217333832-4d76d8f9-ce71-40e6-bd06-aa993035b42d.png)

