### PR TITLE
fix: add extra metrics to mmd

### DIFF
--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -35,3 +35,6 @@ METAMASK_ENVIRONMENT=
 
 # DSN for Sentry
 SENTRY_DSN=
+
+# Write key for Segment
+SEGMENT_WRITE_KEY=

--- a/packages/app/src/app/desktop-app.test.ts
+++ b/packages/app/src/app/desktop-app.test.ts
@@ -49,7 +49,11 @@ jest.mock(
 jest.mock(
   'electron',
   () => ({
-    app: { whenReady: jest.fn(), disableHardwareAcceleration: jest.fn() },
+    app: {
+      whenReady: jest.fn(),
+      disableHardwareAcceleration: jest.fn(),
+      getLoginItemSettings: jest.fn(),
+    },
     BrowserWindow: jest.fn(),
     ipcMain: { handle: jest.fn() },
   }),

--- a/packages/app/src/app/metrics/metrics-constants.ts
+++ b/packages/app/src/app/metrics/metrics-constants.ts
@@ -9,6 +9,8 @@ export const EVENT_NAMES = {
   DESKTOP_APP_STARTING: 'Desktop App Starting',
   DESKTOP_UI_LOADED: 'Desktop UI Loaded',
   UI_CRITICAL_ERROR: 'Desktop UI Critical Error',
+  DESKTOP_APP_UNPAIRED: 'Desktop App Unpaired',
+  DESKTOP_APP_OPENED_STARTUP: 'Desktop App Opened at Startup',
 };
 
 export enum MetricsDecision {


### PR DESCRIPTION
## Overview
The aim of this PR is to include additional metrics that allow keeping track of desktop ORKs.

## Changes
- added metrics using the track method from `metrics-service.ts`
   -  `DESKTOP_APP_UNPAIRED`
   - `DESKTOP_APP_OPENED_STARTUP`
   - `INVALID_OTP`

### List of events by ticket

[223 - add metrics MMD](https://github.com/MetaMask/metamask-desktop/issues/223)
- Invalid OTP
- Desktop App Unpaired

[494 - Capture the event when a Desktop app is opened](https://github.com/MetaMask/metamask-desktop/issues/494)
- added event on [PR](https://github.com/MetaMask/metamask-desktop/pull/472/files#diff-a97e17bd5cc9560b59ac7b99c84969a9b495e29d0b0128fd990c25723e692a26R114)

[495 - Capture the event when a Desktop app is opened at startup](https://github.com/MetaMask/metamask-desktop/issues/495)
- Desktop App Opened at Startup

## Issues

closes: #223 #494 #495