### PR TITLE
chore: remove vulnerabilities

### DIFF
--- a/packages/app/.iyarc
+++ b/packages/app/.iyarc
@@ -1,11 +1,11 @@
 # improved-yarn-audit advisory exclusions
 GHSA-257v-vj4p-3w2h
-GHSA-hrpp-h998-j3pp
-GHSA-h452-7996-h45h
+
+# yarn berry's `yarn npm audit` script reports the following vulnerability but
+# it is a false positive. The offending version of 'ws' that is installed is
+# 7.1.1 and is included only via remote-redux-devtools which is a devDependency
+GHSA-6fc8-4gx4-v693
 
 # pending review
-GHSA-9c47-m6qq-7p4h
 GHSA-3xq5-wjfh-ppjc
-GHSA-6fc8-4gx4-v693
-GHSA-h452-7996-h45h
-GHSA-rc47-6667-2j5j
+GHSA-hrpp-h998-j3pp

--- a/packages/common/.iyarc
+++ b/packages/common/.iyarc
@@ -1,4 +1,9 @@
 # improved-yarn-audit advisory exclusions
+
+# yarn berry's `yarn npm audit` script reports the following vulnerability but
+# it is a false positive. The offending version of 'ws' that is installed is
+# 7.1.1 and is included only via remote-redux-devtools which is a devDependency
 GHSA-6fc8-4gx4-v693
+
+# pending review
 GHSA-f8q6-p94x-37v3
-GHSA-rc47-6667-2j5j

--- a/yarn.lock
+++ b/yarn.lock
@@ -13320,9 +13320,9 @@ __metadata:
   linkType: hard
 
 "cookiejar@npm:^2.1.0":
-  version: 2.1.3
-  resolution: "cookiejar@npm:2.1.3"
-  checksum: 88259983ebc52ceb23cdacfa48762b6a518a57872eff1c7ed01d214fff5cf492e2660d7d5c04700a28f1787a76811df39e8639f8e17670b3cf94ecd86e161f07
+  version: 2.1.4
+  resolution: "cookiejar@npm:2.1.4"
+  checksum: c4442111963077dc0e5672359956d6556a195d31cbb35b528356ce5f184922b99ac48245ac05ed86cf993f7df157c56da10ab3efdadfed79778a0d9b1b092d5b
   languageName: node
   linkType: hard
 
@@ -20313,9 +20313,9 @@ __metadata:
   linkType: hard
 
 "http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "http-cache-semantics@npm:4.1.0"
-  checksum: 974de94a81c5474be07f269f9fd8383e92ebb5a448208223bfb39e172a9dbc26feff250192ecc23b9593b3f92098e010406b0f24bd4d588d631f80214648ed42
+  version: 4.1.1
+  resolution: "http-cache-semantics@npm:4.1.1"
+  checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236
   languageName: node
   linkType: hard
 
@@ -23466,13 +23466,13 @@ __metadata:
   linkType: hard
 
 "json5@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json5@npm:1.0.1"
+  version: 1.0.2
+  resolution: "json5@npm:1.0.2"
   dependencies:
     minimist: ^1.2.0
   bin:
     json5: lib/cli.js
-  checksum: e76ea23dbb8fc1348c143da628134a98adf4c5a4e8ea2adaa74a80c455fc2cdf0e2e13e6398ef819bfe92306b610ebb2002668ed9fc1af386d593691ef346fc3
+  checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updated dependencies to clear vulnerabilities.

Used:
```
yarn up --recursive http-cache-semantics
yarn up --recursive cookiejar
yarn up --recursive json5
```

I've left under the `pending review` comment those that could not be resolved by updating subdependencies to a version that is compatible.

There are two vulnerabilities that are shared with the extension. For those, I have copied the same text that is being used in the extension code.
```
GHSA-257v-vj4p-3w2h
GHSA-6fc8-4gx4-v693
```
