### PR TITLE
fix: collect errors using error boundary

### DIFF
--- a/packages/app/lavamoat/ui/browserify/policy.json
+++ b/packages/app/lavamoat/ui/browserify/policy.json
@@ -49,6 +49,117 @@
         "crypto.getRandomValues": true
       }
     },
+    "@sentry/browser": {
+      "globals": {
+        "XMLHttpRequest": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/browser>tslib": true,
+        "@sentry/types": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core": {
+      "globals": {
+        "clearInterval": true,
+        "console.warn": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core>@sentry/hub": true,
+        "@sentry/browser>@sentry/core>@sentry/minimal": true,
+        "@sentry/browser>@sentry/core>tslib": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/hub": {
+      "globals": {
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "packages": {
+        "@sentry/browser>@sentry/core>@sentry/hub>tslib": true,
+        "@sentry/utils": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/hub>tslib": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/minimal": {
+      "packages": {
+        "@sentry/browser>@sentry/core>@sentry/hub": true,
+        "@sentry/browser>@sentry/core>@sentry/minimal>tslib": true
+      }
+    },
+    "@sentry/browser>@sentry/core>@sentry/minimal>tslib": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@sentry/browser>@sentry/core>tslib": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@sentry/browser>tslib": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@sentry/electron": {
+      "globals": {
+        "__SENTRY_IPC__": true,
+        "__SENTRY__RENDERER_INIT__": "write",
+        "console.error": true,
+        "fetch": true
+      },
+      "packages": {
+        "@sentry/browser": true,
+        "@sentry/browser>@sentry/core": true,
+        "@sentry/electron>tslib": true,
+        "@sentry/types": true,
+        "@sentry/utils": true,
+        "addons-linter>deepmerge": true
+      }
+    },
+    "@sentry/electron>tslib": {
+      "globals": {
+        "define": true
+      }
+    },
+    "@sentry/utils": {
+      "globals": {
+        "CustomEvent": true,
+        "DOMError": true,
+        "DOMException": true,
+        "Element": true,
+        "ErrorEvent": true,
+        "Event": true,
+        "Headers": true,
+        "Request": true,
+        "Response": true,
+        "XMLHttpRequest.prototype": true,
+        "__SENTRY_BROWSER_BUNDLE__": true,
+        "clearTimeout": true,
+        "console.error": true,
+        "document": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@sentry/types": true,
+        "@sentry/utils>tslib": true,
+        "browserify>process": true
+      }
+    },
+    "@sentry/utils>tslib": {
+      "globals": {
+        "define": true
+      }
+    },
     "@storybook/api>util-deprecate": {
       "globals": {
         "console.trace": true,

--- a/packages/app/src/ui/helpers/i18n-helper.js
+++ b/packages/app/src/ui/helpers/i18n-helper.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import * as Sentry from '@sentry/electron/renderer';
 import { getPureMessage } from '../../shared/locales/getPureMessage';
-// import * as Sentry from '@sentry/browser';
+
 const missingSubstitutionErrors = {};
 
 export const getMessage = (localeCode, localeMessages, key, substitutions) => {
@@ -40,7 +41,7 @@ export const getMessage = (localeCode, localeMessages, key, substitutions) => {
           `Insufficient number of substitutions for key "${key}" with locale "${localeCode}"`,
         );
         __electronLog.error(error);
-        // Sentry.captureException(error);
+        Sentry.captureException(error);
       }
       return substitutions[substituteIndex];
     });

--- a/packages/app/src/ui/pages/index.js
+++ b/packages/app/src/ui/pages/index.js
@@ -4,6 +4,7 @@ import { HashRouter } from 'react-router-dom';
 import { PersistGate } from 'redux-persist/integration/react';
 import PropTypes from 'prop-types';
 
+import * as Sentry from '@sentry/electron/renderer';
 import { I18nProvider } from '../contexts/i18n';
 import { EVENT_NAMES } from '../../app/metrics/metrics-constants';
 import Routes from './routes';
@@ -17,7 +18,7 @@ class Root extends PureComponent {
   }
 
   componentDidCatch(error) {
-    // TODO: Sentry.captureException(error);
+    Sentry.captureException(error);
     window.electronBridge.track(EVENT_NAMES.UI_CRITICAL_ERROR);
     console.error('Exception Error Page', error);
   }


### PR DESCRIPTION
# Overview

This PR aims to enable errors to be handled by the error boundary on the UI and send to Sentry on the render process.

![image 20230215111558](https://user-images.githubusercontent.com/45455812/219015114-48d6b5c7-11e7-48b9-b8c5-7e35d8e50c37.png)

# Issues  
resolves: #463 

