### PR TITLE
fix: increase brute force protection TOTP

### DIFF
--- a/packages/common/src/utils/totp.test.ts
+++ b/packages/common/src/utils/totp.test.ts
@@ -1,6 +1,6 @@
 import { TOTP as TOTPAuth } from 'otpauth';
 import { OTP_MOCK, WRONG_OTP_MOCK } from '../../test/mocks';
-import TOTP from './totp';
+import TOTP, { MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS } from './totp';
 
 describe('TOTP', () => {
   let validateMock: jest.SpyInstance;
@@ -40,11 +40,14 @@ describe('TOTP', () => {
   });
 
   it('resets TOTP instance after exceed the max attempts within 30 seconds', async () => {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS; i++) {
       TOTP.validate(WRONG_OTP_MOCK);
       expect(validateMock).toHaveBeenCalled();
     }
-    expect(validateMock).toHaveBeenCalledTimes(10);
+
+    expect(validateMock).toHaveBeenCalledTimes(
+      MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS,
+    );
     expect(initMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/common/src/utils/totp.ts
+++ b/packages/common/src/utils/totp.ts
@@ -1,7 +1,7 @@
 import * as OTPAuth from 'otpauth';
 import { randomHex } from './crypto';
 
-const MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS = 10;
+export const MAX_TOTP_VALIDATE_RETRY_IN_30_SECONDS = 5;
 class TOTP {
   private static instance: OTPAuth.TOTP;
 


### PR DESCRIPTION
# Overview

This PR aims to increase brute force protection on TOTP setting max attempts within 30 seconds to 5.

# Changes

## Common
- set max attempts within 30 seconds to `5`.


## Issues
resolves: #522 
