### PR TITLE
fix: add graceful shutdown for sentry to flush all pending messages

### DIFF
--- a/packages/app/lavamoat/node/policy.json
+++ b/packages/app/lavamoat/node/policy.json
@@ -2461,8 +2461,11 @@
       "globals": {
         "Buffer.concat": true,
         "Buffer.from": true,
+        "__SENTRY_IPC__": true,
+        "__SENTRY__RENDERER_INIT__": "write",
         "clearInterval": true,
         "console.error": true,
+        "fetch": true,
         "process.arch": true,
         "process.execPath": true,
         "process.getSystemMemoryInfo": true,
@@ -2480,6 +2483,7 @@
         "setTimeout": true
       },
       "packages": {
+        "@sentry/browser": true,
         "@sentry/browser>@sentry/core": true,
         "@sentry/electron>@sentry/node": true,
         "@sentry/electron>deepmerge": true,

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -32,7 +32,10 @@ import AppEvents from './ui/app-events';
 import WindowService from './ui/window-service';
 import UIState from './ui/ui-state';
 import { setLanguage, t } from './utils/translation';
-import { setUiStorage } from './storage/ui-storage';
+import {
+  readPersistedSettingFromAppState,
+  setUiStorage,
+} from './storage/ui-storage';
 import MetricsService from './metrics/metrics-service';
 import { EVENT_NAMES } from './metrics/metrics-constants';
 
@@ -151,6 +154,13 @@ class DesktopApp extends EventEmitter {
 
     ipcMain.handle('get-desktop-version', () => {
       return getDesktopVersion();
+    });
+
+    ipcMain.handle('get-desktop-metrics-decision', () => {
+      return readPersistedSettingFromAppState({
+        defaultValue: false,
+        key: 'metametricsOptIn',
+      });
     });
 
     setUiStorage(uiAppStorage);

--- a/packages/app/src/app/globals.ts
+++ b/packages/app/src/app/globals.ts
@@ -98,16 +98,10 @@ if (!global.self) {
           const extensionMetaMetricsOptIn =
             extensionState.store?.metamask?.participateInMetaMetrics;
 
-          const desktopMetaMetricsOptInValue = readPersistedSettingFromAppState(
-            {
-              defaultValue: false,
-              key: 'metametricsOptIn',
-            },
-          );
-          const desktopMetaMetricsOptIn =
-            typeof desktopMetaMetricsOptInValue === 'string'
-              ? desktopMetaMetricsOptInValue === 'true'
-              : desktopMetaMetricsOptInValue;
+          const desktopMetaMetricsOptIn = readPersistedSettingFromAppState({
+            defaultValue: false,
+            key: 'metametricsOptIn',
+          });
 
           // Desktop opt in must be enabled
           // Extension opt in must be enabled if desktop currently enabled
@@ -122,7 +116,7 @@ if (!global.self) {
             shouldShareMetrics,
           });
 
-          return shouldShareMetrics;
+          return false;
         },
       }) as Integration,
       new Dedupe() as Integration,

--- a/packages/app/src/app/globals.ts
+++ b/packages/app/src/app/globals.ts
@@ -116,7 +116,7 @@ if (!global.self) {
             shouldShareMetrics,
           });
 
-          return false;
+          return shouldShareMetrics;
         },
       }) as Integration,
       new Dedupe() as Integration,

--- a/packages/app/src/app/log/sentry-install.ts
+++ b/packages/app/src/app/log/sentry-install.ts
@@ -4,21 +4,44 @@ import { Integration } from '@sentry/types/dist/integration';
 import { getSentryDefaultOptions } from './setup-sentry';
 
 declare const global: typeof globalThis & {
+  stateHooks: Record<string, any>;
   sentry: unknown;
 };
 const sentryDefaultOptions = getSentryDefaultOptions(
   `${process.env.PACKAGE_VERSION}-desktop.0`,
 );
 
+const getState = () => global.stateHooks?.getSentryState?.() || {};
+
 Sentry.init({
   ...sentryDefaultOptions,
   integrations: [
-    // TODO
-    // We are not currently sending metrics through this Sentry instance
-    // Add filter when we do
     new Dedupe() as Integration,
     new ExtraErrorData() as Integration,
   ],
+  beforeSend: async (event) => {
+    const extensionState = getState();
+
+    const hasValidExtensionState =
+      extensionState.store?.metamask?.desktopEnabled;
+
+    const extensionMetaMetricsOptIn =
+      extensionState.store?.metamask?.participateInMetaMetrics;
+
+    const desktopMetaMetricsOptIn =
+      await window.electronBridge.getDesktopMetricsDecision();
+
+    // Desktop opt in must be enabled
+    // Extension opt in must be enabled if desktop currently enabled
+    const shouldShareMetrics =
+      (desktopMetaMetricsOptIn && !hasValidExtensionState) ||
+      extensionMetaMetricsOptIn;
+    if (shouldShareMetrics) {
+      return event;
+    }
+
+    return null;
+  },
 });
 
 global.sentry = Sentry;

--- a/packages/app/src/app/ui/app-events.ts
+++ b/packages/app/src/app/ui/app-events.ts
@@ -1,5 +1,5 @@
 import { app, globalShortcut } from 'electron';
-import * as Sentry from '@sentry/electron';
+import * as Sentry from '@sentry/electron/renderer';
 import cfg from '../utils/config';
 import { determineLoginItemSettings } from '../utils/settings';
 import { readPersistedSettingFromAppState } from '../storage/ui-storage';

--- a/packages/app/src/app/ui/app-events.ts
+++ b/packages/app/src/app/ui/app-events.ts
@@ -1,4 +1,5 @@
 import { app, globalShortcut } from 'electron';
+import * as Sentry from '@sentry/electron';
 import cfg from '../utils/config';
 import { determineLoginItemSettings } from '../utils/settings';
 import { readPersistedSettingFromAppState } from '../storage/ui-storage';
@@ -62,6 +63,13 @@ export default class AppEvents {
         this.UIState.mainWindow?.webContents.openDevTools();
       });
     }
+
+    // Drain any remaining events before closing
+    app.on('before-quit', async () => {
+      const sentryClient = Sentry.getCurrentHub().getClient();
+      await sentryClient?.flush(2000);
+      sentryClient?.close();
+    });
   }
 
   private onSecondInstance() {

--- a/packages/app/src/app/ui/preload.ts
+++ b/packages/app/src/app/ui/preload.ts
@@ -82,6 +82,9 @@ const electronBridge = {
       metricsDecision,
     );
   },
+  getDesktopMetricsDecision: () => {
+    return ipcRenderer.invoke('get-desktop-metrics-decision');
+  },
 };
 
 contextBridge.exposeInMainWorld('electronBridge', electronBridge);


### PR DESCRIPTION
# Overview

This PR aims to add a graceful shutdown mechanism for Sentry to send any pending messages.

# Changes

## App

- added a listener to the electron app for 'before-quit' and a timeout to send any pending messages to Sentry.
- included metrics decision filter to the renderer process.

## Issues
resolves #201