### PR TITLE
Improve symmetric encryption performance

### DIFF
--- a/packages/app/lavamoat/node/policy.json
+++ b/packages/app/lavamoat/node/policy.json
@@ -771,6 +771,8 @@
       },
       "globals": {
         "Buffer.from": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
         "WebSocket": true,
         "clearInterval": true,
         "clearTimeout": true,

--- a/packages/common/src/encryption/symmetric.test.ts
+++ b/packages/common/src/encryption/symmetric.test.ts
@@ -1,15 +1,13 @@
 import {
-  DECRYPTED_BUFFER_MOCK,
+  DECRYPTED_MOCK,
   DECRYPTED_STRING_MOCK,
-  ENCRYPTED_BUFFER_MOCK,
-  ENCRYPTED_HEX_MOCK,
-  EXPORTED_KEY_HEX_MOCK,
-  EXPORTED_KEY_MOCK,
-  IV_BUFFER_MOCK,
-  IV_HEX_MOCK,
+  ENCRYPTED_BYTES_MOCK,
+  ENCRYPTED_MOCK,
+  IV_BYTES_MOCK,
+  IV_MOCK,
+  KEY_BYTES_MOCK,
+  KEY_EXPORTED_MOCK,
   KEY_MOCK,
-  STRING_DATA_BUFFER_MOCK,
-  STRING_DATA_MOCK,
 } from '../../test/mocks';
 import { createKey, decrypt, encrypt } from './symmetric';
 
@@ -41,11 +39,11 @@ describe('Symmetric Encryption', () => {
   describe('createKey', () => {
     it('generates key using global crypto object', async () => {
       cryptoSubtleMock.generateKey.mockResolvedValueOnce(KEY_MOCK);
-      cryptoSubtleMock.exportKey.mockResolvedValueOnce(EXPORTED_KEY_MOCK);
+      cryptoSubtleMock.exportKey.mockResolvedValueOnce(KEY_EXPORTED_MOCK);
 
       const key = await createKey();
 
-      expect(key).toStrictEqual(EXPORTED_KEY_HEX_MOCK);
+      expect(key).toStrictEqual(KEY_BYTES_MOCK);
 
       expect(cryptoSubtleMock.generateKey).toHaveBeenCalledTimes(1);
       expect(cryptoSubtleMock.exportKey).toHaveBeenCalledTimes(1);
@@ -54,44 +52,44 @@ describe('Symmetric Encryption', () => {
 
   describe('encrypt', () => {
     it('encrypts data using global crypto object', async () => {
-      cryptoMock.getRandomValues.mockReturnValueOnce(IV_BUFFER_MOCK);
-      cryptoSubtleMock.encrypt.mockResolvedValueOnce(ENCRYPTED_BUFFER_MOCK);
+      cryptoMock.getRandomValues.mockReturnValueOnce(IV_MOCK);
+      cryptoSubtleMock.encrypt.mockResolvedValueOnce(ENCRYPTED_MOCK);
 
-      const result = await encrypt(STRING_DATA_MOCK, EXPORTED_KEY_HEX_MOCK);
+      const result = await encrypt(DECRYPTED_STRING_MOCK, KEY_BYTES_MOCK);
 
       expect(result).toStrictEqual({
-        data: ENCRYPTED_HEX_MOCK,
-        iv: IV_HEX_MOCK,
+        data: ENCRYPTED_BYTES_MOCK,
+        iv: IV_BYTES_MOCK,
       });
 
       expect(cryptoMock.getRandomValues).toHaveBeenCalledTimes(1);
 
       expect(cryptoSubtleMock.encrypt).toHaveBeenCalledTimes(1);
       expect(cryptoSubtleMock.encrypt).toHaveBeenCalledWith(
-        { name: 'AES-GCM', iv: IV_BUFFER_MOCK },
+        { name: 'AES-GCM', iv: IV_MOCK },
         KEY_MOCK,
-        STRING_DATA_BUFFER_MOCK,
+        DECRYPTED_MOCK,
       );
     });
   });
 
   describe('decrypt', () => {
     it('decrypts data using global crypto object', async () => {
-      cryptoSubtleMock.decrypt.mockResolvedValueOnce(DECRYPTED_BUFFER_MOCK);
+      cryptoSubtleMock.decrypt.mockResolvedValueOnce(DECRYPTED_MOCK);
 
       const result = await decrypt(
-        ENCRYPTED_HEX_MOCK,
-        EXPORTED_KEY_HEX_MOCK,
-        IV_HEX_MOCK,
+        ENCRYPTED_BYTES_MOCK,
+        KEY_BYTES_MOCK,
+        IV_BYTES_MOCK,
       );
 
       expect(result).toStrictEqual(DECRYPTED_STRING_MOCK);
 
       expect(cryptoSubtleMock.decrypt).toHaveBeenCalledTimes(1);
       expect(cryptoSubtleMock.decrypt).toHaveBeenCalledWith(
-        { name: 'AES-GCM', iv: IV_BUFFER_MOCK },
+        { name: 'AES-GCM', iv: IV_MOCK },
         KEY_MOCK,
-        ENCRYPTED_BUFFER_MOCK,
+        ENCRYPTED_MOCK,
       );
     });
   });

--- a/packages/common/src/encryption/web-socket-stream.test.ts
+++ b/packages/common/src/encryption/web-socket-stream.test.ts
@@ -11,10 +11,12 @@ import {
   STRING_DATA_MOCK,
   createWebSocketNodeMock,
   createWebSocketStreamMock,
-  EXPORTED_KEY_HEX_MOCK,
-  IV_HEX_MOCK,
   DECRYPTED_STRING_MOCK,
+  KEY_EXPORTED_HEX_MOCK,
+  KEY_BYTES_MOCK,
   ENCRYPTED_HEX_MOCK,
+  ENCRYPTED_BYTES_MOCK,
+  IV_BYTES_MOCK,
 } from '../../test/mocks';
 import { flushPromises, simulateNodeEvent } from '../../test/utils';
 import EncryptedWebSocketStream from './web-socket-stream';
@@ -63,16 +65,16 @@ describe('Encrypted Web Socket Stream', () => {
     asymmetricEncryptionMock.decrypt.mockReturnValue(DECRYPTED_STRING_MOCK);
     asymmetricEncryptionMock.encrypt.mockReturnValue(ENCRYPTED_HEX_MOCK);
 
-    symmetricEncryptionMock.createKey.mockResolvedValue(EXPORTED_KEY_HEX_MOCK);
+    symmetricEncryptionMock.createKey.mockResolvedValue(KEY_BYTES_MOCK);
     symmetricEncryptionMock.decrypt.mockResolvedValue(DECRYPTED_STRING_MOCK);
     symmetricEncryptionMock.encrypt.mockResolvedValue({
-      data: ENCRYPTED_HEX_MOCK,
-      iv: IV_HEX_MOCK,
+      data: ENCRYPTED_BYTES_MOCK,
+      iv: IV_BYTES_MOCK,
     });
 
     asymmetricEncryptionMock.decrypt.mockReturnValueOnce(
       JSON.stringify({
-        symmetricKey: EXPORTED_KEY_HEX_MOCK,
+        symmetricKey: KEY_BYTES_MOCK,
       }),
     );
 
@@ -99,7 +101,7 @@ describe('Encrypted Web Socket Stream', () => {
     });
 
     await simulateNodeEvent(webSocketStreamMock, 'data', {
-      symmetricKey: EXPORTED_KEY_HEX_MOCK,
+      symmetricKey: KEY_EXPORTED_HEX_MOCK,
     });
 
     await simulateNodeEvent(
@@ -126,7 +128,7 @@ describe('Encrypted Web Socket Stream', () => {
       expect(asymmetricEncryptionMock.encrypt).toHaveBeenCalledTimes(1);
       expect(asymmetricEncryptionMock.encrypt).toHaveBeenCalledWith(
         JSON.stringify({
-          symmetricKey: EXPORTED_KEY_HEX_MOCK,
+          symmetricKey: KEY_BYTES_MOCK,
         }),
         PUBLIC_KEY_MOCK,
       );
@@ -134,7 +136,7 @@ describe('Encrypted Web Socket Stream', () => {
       expect(symmetricEncryptionMock.encrypt).toHaveBeenCalledTimes(1);
       expect(symmetricEncryptionMock.encrypt).toHaveBeenCalledWith(
         MESSAGE_HANDSHAKE_FINISH,
-        EXPORTED_KEY_HEX_MOCK,
+        KEY_BYTES_MOCK,
       );
 
       expect(webSocketStreamMock.write).toHaveBeenCalledTimes(4);
@@ -157,7 +159,7 @@ describe('Encrypted Web Socket Stream', () => {
       );
 
       expect(webSocketStreamMock.write).toHaveBeenCalledWith(
-        { data: ENCRYPTED_HEX_MOCK, iv: IV_HEX_MOCK },
+        { data: ENCRYPTED_BYTES_MOCK, iv: IV_BYTES_MOCK },
         undefined,
         expect.any(Function),
       );
@@ -178,15 +180,15 @@ describe('Encrypted Web Socket Stream', () => {
         encryptedWebSocketStream.on('data', pushCallback);
 
         await simulateNodeEvent(webSocketStreamMock, 'data', {
-          data: DATA_MOCK,
-          iv: IV_HEX_MOCK,
+          data: ENCRYPTED_BYTES_MOCK,
+          iv: IV_BYTES_MOCK,
         });
 
         expect(symmetricEncryptionMock.decrypt).toHaveBeenCalledTimes(3);
         expect(symmetricEncryptionMock.decrypt).toHaveBeenLastCalledWith(
-          DATA_MOCK,
-          EXPORTED_KEY_HEX_MOCK,
-          IV_HEX_MOCK,
+          ENCRYPTED_BYTES_MOCK,
+          KEY_BYTES_MOCK,
+          IV_BYTES_MOCK,
         );
 
         expect(pushCallback).toHaveBeenCalledTimes(1);
@@ -203,7 +205,7 @@ describe('Encrypted Web Socket Stream', () => {
 
   describe('write', () => {
     it.each([
-      ['string', STRING_DATA_MOCK, STRING_DATA_MOCK],
+      ['string', DECRYPTED_STRING_MOCK, DECRYPTED_STRING_MOCK],
       ['object', DATA_MOCK, JSON_MOCK],
     ])(
       'encrypts %s message and writes to web socket stream',
@@ -214,12 +216,12 @@ describe('Encrypted Web Socket Stream', () => {
         expect(symmetricEncryptionMock.encrypt).toHaveBeenCalledTimes(2);
         expect(symmetricEncryptionMock.encrypt).toHaveBeenLastCalledWith(
           valueToEncrypt,
-          EXPORTED_KEY_HEX_MOCK,
+          KEY_BYTES_MOCK,
         );
 
         expect(webSocketStreamMock.write).toHaveBeenCalledTimes(5);
         expect(webSocketStreamMock.write).toHaveBeenLastCalledWith(
-          { data: ENCRYPTED_HEX_MOCK, iv: IV_HEX_MOCK },
+          { data: ENCRYPTED_BYTES_MOCK, iv: IV_BYTES_MOCK },
           undefined,
           expect.any(Function),
         );

--- a/packages/common/src/encryption/web-socket-stream.ts
+++ b/packages/common/src/encryption/web-socket-stream.ts
@@ -30,11 +30,11 @@ export default class EncryptedWebSocketStream extends Duplex {
 
   private asymmetricKeyPair?: asymmetricEncryption.KeyPair;
 
-  private symmetricKey?: string;
+  private symmetricKey?: number[];
 
   private targetPublicKey?: string;
 
-  private targetSymmetricKey?: string;
+  private targetSymmetricKey?: number[];
 
   private performingHandshake: boolean;
 

--- a/packages/common/src/pairing.test.ts
+++ b/packages/common/src/pairing.test.ts
@@ -2,9 +2,10 @@ import ObjectMultiplex from 'obj-multiplex';
 import {
   createMultiplexMock,
   createStreamMock,
-  DECRYPTED_STRING_MOCK,
   HASH_BUFFER_2_HEX_MOCK,
   HASH_BUFFER_HEX_MOCK,
+  KEY_BYTES_MOCK,
+  KEY_EXPORTED_HEX_MOCK,
   OTP_MOCK,
   STRING_DATA_MOCK,
 } from '../test/mocks';
@@ -81,7 +82,7 @@ describe('Pairing', () => {
 
     describe('if OTP is valid', () => {
       beforeEach(async () => {
-        encryptionMock.createKey.mockResolvedValue(DECRYPTED_STRING_MOCK);
+        encryptionMock.createKey.mockResolvedValue(KEY_BYTES_MOCK);
         hashStringMock.mockResolvedValueOnce(STRING_DATA_MOCK);
 
         totpMock.validate.mockReturnValue(true);
@@ -107,7 +108,7 @@ describe('Pairing', () => {
         expect(requestStreamMock.write).toHaveBeenCalledTimes(1);
         expect(requestStreamMock.write).toHaveBeenCalledWith({
           isDesktopEnabled: true,
-          pairingKey: DECRYPTED_STRING_MOCK,
+          pairingKey: KEY_EXPORTED_HEX_MOCK,
         });
       });
     });

--- a/packages/common/src/pairing.ts
+++ b/packages/common/src/pairing.ts
@@ -104,7 +104,7 @@ export class Pairing {
       return;
     }
 
-    const pairingKey = await createKey();
+    const pairingKey = Buffer.from(await createKey()).toString('hex');
     const pairingKeyHash = await hashString(pairingKey, { isHex: true });
 
     await rawState.setDesktopState({

--- a/packages/common/test/mocks.ts
+++ b/packages/common/test/mocks.ts
@@ -17,19 +17,8 @@ export const VALUE_MOCK = 'value';
 export const VALUE_2_MOCK = 'value2';
 export const DATA_MOCK = { [PROPERTY_MOCK]: VALUE_MOCK };
 export const DATA_2_MOCK = { [PROPERTY_2_MOCK]: VALUE_2_MOCK };
-export const DECRYPTED_STRING_MOCK = 'testDecryptedData';
-export const DECRYPTED_BUFFER_MOCK = Buffer.from(DECRYPTED_STRING_MOCK);
-export const ENCRYPTED_BUFFER_MOCK = Buffer.from([4, 5, 6]);
-export const ENCRYPTED_HEX_MOCK = Buffer.from(ENCRYPTED_BUFFER_MOCK).toString(
-  'hex',
-);
-export const EXPORTED_KEY_MOCK = Buffer.from([1, 2, 3]);
-export const EXPORTED_KEY_HEX_MOCK =
-  Buffer.from(EXPORTED_KEY_MOCK).toString('hex');
-export const IV_BUFFER_MOCK = Buffer.from([7, 8, 9]);
-export const IV_HEX_MOCK = Buffer.from(IV_BUFFER_MOCK).toString('hex');
+export const IV_BUFFER_MOCK = Uint8Array.from([7, 8, 9]);
 export const JSON_MOCK = '{"test":"value"}';
-export const KEY_MOCK = {} as CryptoKey;
 export const PUBLIC_KEY_MOCK = 'testPublicKey';
 export const PRIVATE_KEY_MOCK = 'testPrivateKey';
 export const STRING_DATA_MOCK = 'testStringData';
@@ -51,6 +40,19 @@ export const WRONG_OTP_MOCK = '654321';
 export const REMOTE_PORT_NAME_MOCK = 'testPort';
 export const REMOTE_PORT_SENDER_MOCK = { test2: 'value2' };
 export const JSON_RPC_ID_MOCK = 123456;
+export const KEY_BYTES_MOCK = [4, 5, 6];
+export const KEY_MOCK = {} as CryptoKey;
+export const KEY_EXPORTED_MOCK = Uint8Array.from(KEY_BYTES_MOCK);
+export const KEY_EXPORTED_HEX_MOCK =
+  Buffer.from(KEY_BYTES_MOCK).toString('hex');
+export const IV_BYTES_MOCK = [7, 8, 9];
+export const IV_MOCK = Uint8Array.from(IV_BYTES_MOCK);
+export const ENCRYPTED_BYTES_MOCK = [1, 2, 3];
+export const ENCRYPTED_MOCK = Uint8Array.from([1, 2, 3]);
+export const ENCRYPTED_BUFFER_MOCK = Buffer.from(ENCRYPTED_BYTES_MOCK);
+export const ENCRYPTED_HEX_MOCK = ENCRYPTED_BUFFER_MOCK.toString('hex');
+export const DECRYPTED_STRING_MOCK = 'decryptedData';
+export const DECRYPTED_MOCK = new TextEncoder().encode(DECRYPTED_STRING_MOCK);
 
 export const TEST_CONNECTION_RESULT_MOCK: TestConnectionResult = {
   isConnected: true,

--- a/packages/common/test/setup.ts
+++ b/packages/common/test/setup.ts
@@ -1,4 +1,8 @@
 /* eslint-disable import/unambiguous */
+/* eslint-disable @typescript-eslint/no-shadow */
+
+import { TextEncoder, TextDecoder } from 'util';
+
 // catch rejections that are still unhandled when tests exit
 const unhandledRejections = new Map();
 process.on('unhandledRejection', (reason, promise) => {
@@ -31,3 +35,6 @@ global.clearImmediate =
   global.clearImmediate || ((id) => global.clearTimeout(id));
 
 global.chrome = { runtime: { id: 'testid' } } as any;
+
+global.TextEncoder = TextEncoder as any;
+global.TextDecoder = TextDecoder as any;


### PR DESCRIPTION
# Overview

Improve the performance of the symmetric encryption by removing any hex encoding and instead transferring the encrypted data as byte arrays.

This will be most notable when decrypting many background messages in quick succession, especially large messages such as state messages with the `sendUpdate` method.

The cause of this issue was primarily the hex parsing algorithm in the Browserify `Buffer.from` polyfill. When receiving a background message, browser profiling showed that ~80% of the time spent was simply converting hex data to byte arrays.

A synthetic benchmark ran in the extension showed a reduction of 75% from ~1.4ms per iteration to ~0.35ms when decrypting a 5KB message 100,000 times.

# Changes

## Common

- Remove all hex encoding and decoding.
- Update related unit tests and mock data.

## App

- Update LavaMoat policies.
