### PR TITLE
chore: replace github links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The MetaMask Desktop app is one of many experiments we are exploring to improve 
 
 This is useful for use cases like the execution of complex Snaps (e.g. zk-related Snaps), which are very demanding in terms of processing power.
 
-You can find the latest version of MetaMask Desktop app on [our releases page](https://github.com/MetaMask/desktop/releases).
+You can find the latest version of MetaMask Desktop app on [our releases page](https://github.com/MetaMask/metamask-desktop/releases).
 
-For help using MetaMask Desktop, or for general questions, feature requests, and developer questions, see the [Discussions tab](https://github.com/MetaMask/desktop/discussions).
+For help using MetaMask Desktop, or for general questions, feature requests, and developer questions, see the [Discussions tab](https://github.com/MetaMask/metamask-desktop/discussions).
 
 
 ## Monorepo

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0]
 ### Uncategorized
-- chore: remove common browser ([#511](https://github.com/MetaMask/desktop/pull/511))
+- chore: remove common browser ([#511](https://github.com/MetaMask/metamask-desktop/pull/511))
 
 ## [0.1.0]
 ### Uncategorized
@@ -41,6 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move encryption and generic utils to common workspace ([#264](https://github.com/MetaMask/metamask-desktop/pull/264))
 - Move browser and version check logic to common workspace ([#259](https://github.com/MetaMask/metamask-desktop/pull/259))
 
-[Unreleased]: https://github.com/MetaMask/desktop/compare/@metamask/desktop@0.2.0...HEAD
-[0.2.0]: https://github.com/MetaMask/desktop/compare/@metamask/desktop@0.1.0...@metamask/desktop@0.2.0
-[0.1.0]: https://github.com/MetaMask/desktop/releases/tag/@metamask/desktop@0.1.0
+[Unreleased]: https://github.com/MetaMask/metamask-desktop/compare/@metamask/desktop@0.2.0...HEAD
+[0.2.0]: https://github.com/MetaMask/metamask-desktop/compare/@metamask/desktop@0.1.0...@metamask/desktop@0.2.0
+[0.1.0]: https://github.com/MetaMask/metamask-desktop/releases/tag/@metamask/desktop@0.1.0

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -11,6 +11,6 @@ IT CAN ONLY BE USED WITH [FLASK](https://metamask.io/flask/), THE CANARY DISTRIB
 
 The [MetaMask browser extension](https://github.com/MetaMask/metamask-extension) is a crypto wallet & gateway to blockchain apps.
 
-The [MetaMask Desktop app](https://github.com/MetaMask/desktop) is one of many experiments we are exploring to improve our extension-driven experiences. The Desktop app improves the overall performance of the extension when using the [Flask build](https://metamask.io/flask/).
+The [MetaMask Desktop app](https://github.com/MetaMask/metamask-desktop) is one of many experiments we are exploring to improve our extension-driven experiences. The Desktop app improves the overall performance of the extension when using the [Flask build](https://metamask.io/flask/).
 
 This package contains the functions and classes needed to pair the MetaMask browser extension with the MetaMask Desktop app.


### PR DESCRIPTION
## Overview
This PR replaces the old github links for the repository.
