### PR TITLE
fix: metrics paired event to trigger when the pairing key is saved

### DIFF
--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -264,10 +264,6 @@ class DesktopApp extends EventEmitter {
     extensionConnection.on('paired', () => {
       this.status.isDesktopPaired = true;
       this.appNavigation.setPairedTrayIcon();
-      this.metricsService.track(EVENT_NAMES.DESKTOP_APP_PAIRED, {
-        paired: true,
-        createdAt: new Date(),
-      });
     });
 
     extensionConnection.getPairing().on('invalid-otp', () => {

--- a/packages/app/src/app/pairing.test.ts
+++ b/packages/app/src/app/pairing.test.ts
@@ -13,6 +13,9 @@ import { DesktopPairing } from './pairing';
 jest.mock('@metamask/desktop/dist/utils/totp');
 jest.mock('@metamask/desktop/dist/encryption/symmetric');
 jest.mock('obj-multiplex');
+jest.mock('./metrics/metrics-service', () => ({ track: jest.fn() }), {
+  virtual: true,
+});
 
 jest.mock('@metamask/desktop/dist/utils/crypto', () => ({
   randomHex: jest.fn(() => []),

--- a/packages/app/src/app/pairing.ts
+++ b/packages/app/src/app/pairing.ts
@@ -11,11 +11,15 @@ import {
   PairingResultMessage,
 } from '@metamask/desktop/dist/types';
 import * as rawState from '@metamask/desktop/dist/utils/state';
+import MetricsService from './metrics/metrics-service';
+import { EVENT_NAMES } from './metrics/metrics-constants';
 
 export class DesktopPairing extends EventEmitter {
   private requestStream: Duplex;
 
   private keyStream: Duplex;
+
+  private metricsService: typeof MetricsService;
 
   constructor(stream: Duplex) {
     super();
@@ -24,6 +28,7 @@ export class DesktopPairing extends EventEmitter {
 
     this.requestStream = streams.requestStream;
     this.keyStream = streams.keyStream;
+    this.metricsService = MetricsService;
   }
 
   public init() {
@@ -60,6 +65,11 @@ export class DesktopPairing extends EventEmitter {
     });
 
     log.debug('Saved pairing key', pairingKey);
+
+    this.metricsService.track(EVENT_NAMES.DESKTOP_APP_PAIRED, {
+      paired: true,
+      createdAt: new Date(),
+    });
 
     acknowledge(this.requestStream);
   }


### PR DESCRIPTION
# Overview

Improve metrics by moving the `paired` event to `pairing.ts`, and it's triggered whenever a pairing key is saved. 

