### PR TITLE
fix: add segement and sentry env vars

### DIFF
--- a/.github/workflows/package-app-dev.yml
+++ b/.github/workflows/package-app-dev.yml
@@ -51,6 +51,8 @@ jobs:
         env:
           INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
           METAMASK_ENVIRONMENT: 'development'
+          SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       - name: Package app for ${{ matrix.os }}
         shell: bash
         run:  |

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -100,6 +100,8 @@ jobs:
         env:
           INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
           METAMASK_ENVIRONMENT: 'production'
+          SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       - name: Package app for ${{ matrix.os }}
         shell: bash
         run:  |

--- a/packages/app/build/ui/config.js
+++ b/packages/app/build/ui/config.js
@@ -11,6 +11,8 @@ const configurationPropertyNames = [
   'INFURA_PROJECT_ID',
   'SKIP_OTP_PAIRING_FLOW',
   'WEB_SOCKET_PORT',
+  'SENTRY_DSN',
+  'SEGMENT_WRITE_KEY',
 ];
 
 /**


### PR DESCRIPTION
# Overview

Fix adding `SENTRY_DSN` and `SEGMENT_WRITE_KEY` to the build and package scripts.

# Changes

## Root

Add `SENTRY_DSN` and `SEGMENT_WRITE_KEY` to `configurationPropertyNames` to be used by the build script.

## Pipeline

Github Actions package workflows:
* Add `SENTRY_DSN` and `SEGMENT_WRITE_KEY` as env vars available to the build process.

## Common
None

## App

None