### PR TITLE
Chore/package with desktop popup feature enabled

### DIFF
--- a/.github/workflows/package-app-dev.yml
+++ b/.github/workflows/package-app-dev.yml
@@ -57,6 +57,8 @@ jobs:
           METAMASK_ENVIRONMENT: 'development'
           SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          DESKTOP_POPUP: ${{ vars.DESKTOP_POPUP }}
+          DISABLE_EXTENSION_POPUP: ${{ vars.DISABLE_EXTENSION_POPUP }}
       - name: Package app for ${{ matrix.os }}
         shell: bash
         run:  |

--- a/.github/workflows/package-app-prod.yml
+++ b/.github/workflows/package-app-prod.yml
@@ -106,7 +106,9 @@ jobs:
           METAMASK_ENVIRONMENT: 'production'
           SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          DESKTOP_ENABLE_UPDATES: true
+          DESKTOP_ENABLE_UPDATES: ${{ vars.DESKTOP_ENABLE_UPDATES }}
+          DESKTOP_POPUP: ${{ vars.DESKTOP_POPUP }}
+          DISABLE_EXTENSION_POPUP: ${{ vars.DISABLE_EXTENSION_POPUP }}
       - name: Package app for ${{ matrix.os }}
         shell: bash
         run:  |

--- a/packages/app/.iyarc
+++ b/packages/app/.iyarc
@@ -1,2 +1,3 @@
 # improved-yarn-audit advisory exclusions
 GHSA-257v-vj4p-3w2h
+GHSA-p8p7-x288-28g6

--- a/packages/app/build/ui/desktop-ui.js
+++ b/packages/app/build/ui/desktop-ui.js
@@ -187,7 +187,7 @@ prod: Create an optimized build for a production environment.`,
     task,
   } = argv;
 
-  const buildType = BuildType.desktopui;
+  const buildType = BuildType.desktop;
 
   // Manually default this to `false` for dev builds only.
   const shouldLintFenceFiles = lintFenceFiles ?? !/dev/iu.test(task);

--- a/packages/app/src/app/browser/node-browser.ts
+++ b/packages/app/src/app/browser/node-browser.ts
@@ -167,7 +167,7 @@ const raw = {
       let { left } = request;
       let proxyWindowCreate;
 
-      if (!cfg().disableExtensionPopup) {
+      if (!cfg().disableExtensionPopup || !windowHandler) {
         left -= request.width + PADDING_POPUP;
         proxyWindowCreate = proxy(['windows', 'create'], [request]);
       }
@@ -182,7 +182,7 @@ const raw = {
     remove: (windowId: string) => {
       let proxyWindowRemove;
 
-      if (!cfg().disableExtensionPopup) {
+      if (!cfg().disableExtensionPopup || !windowHandler) {
         proxyWindowRemove = proxy(['windows', 'remove'], [windowId]);
       }
 
@@ -191,7 +191,7 @@ const raw = {
     update: (windowId: string, request: WindowUpdateRequest) => {
       let proxyWindowUpdate;
 
-      if (!cfg().disableExtensionPopup) {
+      if (!cfg().disableExtensionPopup || !windowHandler) {
         proxyWindowUpdate = proxy(['windows', 'update'], [windowId, request]);
       }
 
@@ -202,7 +202,7 @@ const raw = {
     query: (opts: TabsQuery) => {
       let proxyTabsQuery;
 
-      if (!cfg().disableExtensionPopup) {
+      if (!cfg().disableExtensionPopup || !tabHandler) {
         proxyTabsQuery = proxy(['tabs', 'query'], [opts]);
       }
 

--- a/packages/app/src/app/desktop-app.ts
+++ b/packages/app/src/app/desktop-app.ts
@@ -49,6 +49,7 @@ import { EVENT_NAMES } from './metrics/metrics-constants';
 import { encryptedCypherFilePath } from './storage/storage';
 import { IPCRendererStream } from './ipc-renderer-stream';
 import { TabsQuery } from './types/tabs';
+import sleep from './utils/sleep';
 
 // Set protocol for deeplinking
 if (!cfg().isUnitTest) {
@@ -122,8 +123,10 @@ class DesktopApp extends EventEmitter {
       return dialog.showMessageBox(params);
     });
 
-    ipcMain.handle('toggle-desktop-popup', (_event, isEnabled) => {
+    ipcMain.handle('toggle-desktop-popup', async (_event, isEnabled) => {
       if (cfg().enableDesktopPopup && isEnabled) {
+        // quick hack to avoid race condition between emit the restart and having the UI persisting the isDesktopPopupEnabled
+        await sleep(500);
         this.enableDesktopPopup(false);
       } else {
         this.disableDesktopPopup();

--- a/packages/app/src/app/utils/sleep.ts
+++ b/packages/app/src/app/utils/sleep.ts
@@ -1,0 +1,3 @@
+export default async function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}


### PR DESCRIPTION
# Overview

Adds desktop popup env vars to the packaging github actions.
Fixes a concurrency issue when enabling/disabling the desktop popup from settings page.

# Changes

## Pipeline

* Adds `DESKTOP_POPUP` and `DISABLE_EXTENSION_POPUP` to package dev github action.
* Adds `DESKTOP_POPUP` and `DISABLE_EXTENSION_POPUP` to package prod github action. 

## App

* Fix: displaying the extension popup only when the desktop popup is disabled.
* Fix: race condition when enabling the desktop popup (between renderer process persisting the isDesktopPopupEnabled state and the main process emitting the restart event)
